### PR TITLE
Add multiple prefixes to etcd storage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,10 @@ lazy val commonSettings = Seq(
     "io.circe"                   %% "circe-generic"  % "0.12.2" % Test,
     "org.slf4j"                  % "slf4j-api"       % "1.7.28" % Test
   ),
-  scalafmtOnCompile := true
+  scalafmtOnCompile := true,
+  resolvers += Resolver.sonatypeRepo("releases"),
+  addCompilerPlugin("org.typelevel" % "kind-projector"      % "0.11.0" cross CrossVersion.full),
+  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
 )
 
 lazy val core = project
@@ -80,11 +83,6 @@ lazy val examples = project
   .in(file("examples"))
   .dependsOn(etcd, typesafe, circe)
   .settings(commonSettings)
-  .settings(
-    resolvers += Resolver.sonatypeRepo("releases"),
-    addCompilerPlugin("org.typelevel" % "kind-projector"      % "0.11.0" cross CrossVersion.full),
-    addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
-  )
   .settings(
     name := "reactive-config-examples",
     libraryDependencies ++= Seq(

--- a/core/src/test/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImplTest.scala
+++ b/core/src/test/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImplTest.scala
@@ -57,14 +57,14 @@ class ReactiveConfigImplTest extends WordSpecLike with Matchers with MockitoSuga
       intercept[ReactiveConfigException](config.getOrThrow[String]("key0")).getMessage
         .shouldEqual("Failed to find ValueByKey on key: key0")
     }
-    */
+     */
 
     "return reloadable" in new mocks {
       (for {
         reloadable <- config.reloadable[String]("key1")
-        value1 <- reloadable.get
-        _ <- IO.sleep(3.seconds)
-        value2 <- reloadable.get
+        value1     <- reloadable.get
+        _          <- IO.sleep(3.seconds)
+        value2     <- reloadable.get
       } yield {
         value1 shouldBe "value1"
         value2 shouldBe "value2"

--- a/core/src/test/scala/com/github/fit51/reactiveconfig/reloadable/ReloadableImplTest.scala
+++ b/core/src/test/scala/com/github/fit51/reactiveconfig/reloadable/ReloadableImplTest.scala
@@ -36,7 +36,7 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
     }
 
     implicit val shift = new cats.effect.ContextShift[IO] {
-      override def shift: IO[Unit] = Task.shift.to[IO]
+      override def shift: IO[Unit]                                   = Task.shift.to[IO]
       override def evalOn[A](ec: ExecutionContext)(fa: IO[A]): IO[A] = fa
     }
   }
@@ -50,10 +50,10 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
           ob = Observable.intervalAtFixedRate(2 second, 2 second).take(2).map(_.toString)
         )
         initial <- reloadable.get
-        _ <- IO.sleep(3 seconds)
-        first <- reloadable.get
-        _ <- IO.sleep(3 seconds)
-        second <- reloadable.get
+        _       <- IO.sleep(3 seconds)
+        first   <- reloadable.get
+        _       <- IO.sleep(3 seconds)
+        second  <- reloadable.get
       } yield {
         initial shouldBe "initial"
         first shouldBe "0"
@@ -69,11 +69,11 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
           ob = Observable.intervalAtFixedRate(2 second, 2 second).take(2).map(_.toString)
         )
         mappedReloadable <- initialReloadable.map(function)
-        initial <- mappedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        first <- mappedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        second <- mappedReloadable.get
+        initial          <- mappedReloadable.get
+        _                <- IO.sleep(3 seconds)
+        first            <- mappedReloadable.get
+        _                <- IO.sleep(3 seconds)
+        second           <- mappedReloadable.get
       } yield {
         initial shouldBe "initial_changed"
         first shouldBe "0_changed"
@@ -101,12 +101,12 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
 
         initial1 <- mappedReloadable1.get
         initial2 <- mappedReloadable2.get
-        _ <- IO.sleep(3 seconds)
+        _        <- IO.sleep(3 seconds)
         _ = verify(stop).stop("initial_changed")
         _ = verify(restart).restart("0", "initial_changed")
-        first1 <- mappedReloadable1.get
-        first2 <- mappedReloadable2.get
-        _ <- IO.sleep(3 seconds)
+        first1  <- mappedReloadable1.get
+        first2  <- mappedReloadable2.get
+        _       <- IO.sleep(3 seconds)
         second1 <- mappedReloadable1.get
         second2 <- mappedReloadable2.get
         _ = verify(stop).stop("0_changed")
@@ -132,10 +132,10 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
         mappedReloadable <- initialReloadable.mapF(function)
 
         initial <- mappedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        first <- mappedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        second <- mappedReloadable.get
+        _       <- IO.sleep(3 seconds)
+        first   <- mappedReloadable.get
+        _       <- IO.sleep(3 seconds)
+        second  <- mappedReloadable.get
       } yield {
         initial shouldBe "initial_changed"
         first shouldBe "0_changed"
@@ -159,11 +159,11 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
         )
 
         combinedReloadable <- initialReloadable1.combine(initialReloadable2)(function)
-        initial <- combinedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        first <- combinedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        second <- combinedReloadable.get
+        initial            <- combinedReloadable.get
+        _                  <- IO.sleep(3 seconds)
+        first              <- combinedReloadable.get
+        _                  <- IO.sleep(3 seconds)
+        second             <- combinedReloadable.get
       } yield {
         initial shouldBe Data("initial", -1)
         first shouldBe Data("0", 0)
@@ -185,11 +185,11 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
         )
 
         combinedReloadable <- initialReloadable1.combineF(initialReloadable2)(function)
-        initial <- combinedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        first <- combinedReloadable.get
-        _ <- IO.sleep(3 seconds)
-        second <- combinedReloadable.get
+        initial            <- combinedReloadable.get
+        _                  <- IO.sleep(3 seconds)
+        first              <- combinedReloadable.get
+        _                  <- IO.sleep(3 seconds)
+        second             <- combinedReloadable.get
       } yield {
         initial shouldBe Data("initial", -1)
         first shouldBe Data("0", 0)
@@ -214,7 +214,7 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
         )
         mappedReloadable <- initialReloadable.mapF(s => IO.delay(s * 2), Stop((s: String) => stop.stop(s)))
 
-        _ <- IO.sleep(3500 millis)
+        _   <- IO.sleep(3500 millis)
         cur <- mappedReloadable.get
         _ = verify(stop, times(3)).stop(any())
 
@@ -227,7 +227,7 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
     }
 
     "survive after errors in restart handler" in new mocks {
-      val restart = mock[RestartingService[String, String]]
+      val restart      = mock[RestartingService[String, String]]
       var counter: Int = 0
       when(restart.restart(any(), any())).thenAnswer((invocation: InvocationOnMock) => {
         counter += 1
@@ -246,7 +246,7 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
 
         mappedReloadable <- initialReloadable.mapF(s => IO.delay(s * 2), Restart((a, b) => restart.restart(a, b)))
 
-        _ <- IO.sleep(3500 millis)
+        _   <- IO.sleep(3500 millis)
         cur <- mappedReloadable.get
         _ = verify(restart, times(3)).restart(any(), any())
         _ = verify(restart).restart("0", "initialinitial")
@@ -270,15 +270,15 @@ class ReloadableImplTest extends WordSpecLike with Matchers with MockitoSugar {
           ob = Observable.intervalAtFixedRate(1 second, 1 second).map(_.toString)
         )
         doubleF <- initialReloadable.mapF(s => IO.delay(s * 2), Stop((s: String) => stop.stop(s)))
-        maskF <- doubleF.mapF(s => IO.delay(s.take(1) + "***"), Stop((s: String) => stop.stop(s)))
+        maskF   <- doubleF.mapF(s => IO.delay(s.take(1) + "***"), Stop((s: String) => stop.stop(s)))
 
-        _ <- IO.sleep(1100 millis)
+        _       <- IO.sleep(1100 millis)
         double1 <- doubleF.get
-        mask1 <- maskF.get
+        mask1   <- maskF.get
 
-        _ <- IO.sleep(1 second)
+        _       <- IO.sleep(1 second)
         double2 <- doubleF.get
-        mask2 <- maskF.get
+        mask2   <- maskF.get
 
         _ <- initialReloadable.stop
       } yield {

--- a/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/EtcdConfigStorage.scala
+++ b/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/EtcdConfigStorage.scala
@@ -1,4 +1,5 @@
 package com.github.fit51.reactiveconfig.etcd
+import cats.data.NonEmptyList
 import cats.effect.{Async, ContextShift}
 import cats.syntax.all._
 import com.typesafe.scalalogging.LazyLogging
@@ -20,12 +21,15 @@ object EtcdConfigStorage {
     **/
   def apply[F[_]: Async: ContextShift, Json](
       etcd: EtcdClient[F] with Watch[F],
-      prefix: String
+      prefixes: NonEmptyList[String]
   )(implicit s: Scheduler, encoder: ConfigParser[Json]): EtcdConfigStorage[F, Json] =
-    new EtcdConfigStorage[F, Json](etcd, prefix)
+    new EtcdConfigStorage[F, Json](etcd, prefixes)
 }
 
-class EtcdConfigStorage[F[_]: Async: ContextShift, ParsedData](etcd: EtcdClient[F] with Watch[F], prefix: String)(
+class EtcdConfigStorage[F[_]: Async: ContextShift, ParsedData](
+    etcd: EtcdClient[F] with Watch[F],
+    prefixes: NonEmptyList[String]
+)(
     implicit s: Scheduler,
     encoder: ConfigParser[ParsedData]
 ) extends ConfigStorage[F, ParsedData] with LazyLogging {
@@ -34,25 +38,29 @@ class EtcdConfigStorage[F[_]: Async: ContextShift, ParsedData](etcd: EtcdClient[
   private val storage: TrieMap[String, Value[ParsedData]] = TrieMap.empty
 
   override def load(): F[TrieMap[String, Value[ParsedData]]] =
-    etcd
-      .getRecursiveSinceRevision(prefix, revision)
-      .map {
-        case (kvs, rev) =>
-          revision = rev
-          logger.info(s"EtcdConfig: Updated to rev: $rev")
-          kvs.foreach(saveKeyValue(_, checkVersions = true))
-          storage
-      }
+    prefixes.traverse { prefix =>
+      etcd
+        .getRecursiveSinceRevision(prefix, revision)
+        .map {
+          case (kvs, rev) =>
+            logger.info(s"EtcdConfig: Updated to rev: $rev")
+            kvs.foreach(saveKeyValue(_, checkVersions = true))
+        }
+    } >> storage.pure
 
   override def watch(): F[Observable[ParsedKeyValue[ParsedData]]] =
-    etcd.watch(EtcdUtils.getRange(prefix)).map { observable =>
-      val hotObservable = observable
-        .map(saveKeyValue(_))
-        .collect { case Some(value) => value }
-        .publish
-      hotObservable.connect()
-      hotObservable
-    }
+    prefixes
+      .map(prefix => etcd.watch(EtcdUtils.getRange(prefix)))
+      .sequence
+      .map(obs => Observable.fromIterable(obs.toList).merge)
+      .map { merged =>
+        val hotObservable = merged
+          .map(saveKeyValue(_))
+          .collect { case Some(value) => value }
+          .publish
+        hotObservable.connect()
+        hotObservable
+      }
 
   private def saveKeyValue(kv: KeyValue, checkVersions: Boolean = false): Option[ParsedKeyValue[ParsedData]] =
     encoder.parse(kv.value.utf8) match {

--- a/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcd.scala
+++ b/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcd.scala
@@ -1,5 +1,6 @@
 package com.github.fit51.reactiveconfig.etcd
 
+import cats.data.NonEmptyList
 import cats.effect.{Async, ContextShift}
 import com.github.fit51.reactiveconfig.config.{ReactiveConfig, ReactiveConfigImpl}
 import com.github.fit51.reactiveconfig.parser.ConfigParser
@@ -12,11 +13,11 @@ object ReactiveConfigEtcd {
 
   def apply[F[_]: Async: ContextShift: TaskLike, ParsedData](
       etcdClient: EtcdClient[F] with Watch[F],
-      prefix: String = ""
+      prefixes: NonEmptyList[String] = NonEmptyList.one("")
   )(implicit scheduler: Scheduler, configParser: ConfigParser[ParsedData]): F[ReactiveConfig[F, ParsedData]] = {
     val F = implicitly[Async[F]]
     for {
-      storage <- F.pure(new EtcdConfigStorage[F, ParsedData](etcdClient, prefix))
+      storage <- F.pure(new EtcdConfigStorage[F, ParsedData](etcdClient, prefixes))
       config  <- ReactiveConfigImpl(storage)
     } yield config
   }

--- a/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcd.scala
+++ b/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcd.scala
@@ -1,24 +1,34 @@
 package com.github.fit51.reactiveconfig.etcd
 
-import cats.data.NonEmptyList
+import cats.data.NonEmptySet
 import cats.effect.{Async, ContextShift}
+import cats.implicits._
 import com.github.fit51.reactiveconfig.config.{ReactiveConfig, ReactiveConfigImpl}
 import com.github.fit51.reactiveconfig.parser.ConfigParser
 import monix.execution.Scheduler
-import cats.syntax.flatMap._
-import cats.syntax.functor._
 import monix.eval.TaskLike
 
 object ReactiveConfigEtcd {
 
+  final class IntersectionError(prefixes: List[String]) extends Exception("Prefixes should not intersect.")
+
   def apply[F[_]: Async: ContextShift: TaskLike, ParsedData](
       etcdClient: EtcdClient[F] with Watch[F],
-      prefixes: NonEmptyList[String] = NonEmptyList.one("")
+      prefixes: NonEmptySet[String] = NonEmptySet.one("")
   )(implicit scheduler: Scheduler, configParser: ConfigParser[ParsedData]): F[ReactiveConfig[F, ParsedData]] = {
     val F = implicitly[Async[F]]
     for {
-      storage <- F.pure(new EtcdConfigStorage[F, ParsedData](etcdClient, prefixes))
+      _       <- F.raiseError(new IntersectionError(prefixes.toList)).whenA(doIntersect(prefixes))
+      storage <- F.pure(EtcdConfigStorage[F, ParsedData](etcdClient, prefixes))
       config  <- ReactiveConfigImpl(storage)
     } yield config
+  }
+
+  def doIntersect(prefixes: NonEmptySet[String]): Boolean = {
+    !prefixes.forall { prefix1 =>
+      prefixes.forall { prefix2 =>
+        prefix1 == prefix2 || !prefix1.startsWith(prefix2)
+      }
+    }
   }
 }

--- a/etcd/src/test/scala/com/github/fit51/reactiveconfig/etcd/EtcdClientTest.scala
+++ b/etcd/src/test/scala/com/github/fit51/reactiveconfig/etcd/EtcdClientTest.scala
@@ -16,7 +16,7 @@ class EtcdClientTest extends WordSpecLike with BeforeAndAfterAll with Matchers {
   import EtcdUtils._
   implicit val scheduler = Scheduler.global
 
-  val chManager  = ChannelManager.noAuth("http://127.0.0.1:2379")
+  val chManager = ChannelManager.noAuth("http://127.0.0.1:2379")
   val etcdClient = new EtcdClient[Task](chManager) with Watch[Task] {
     val taskLift = TaskLift[Task]
   }

--- a/etcd/src/test/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcdTest.scala
+++ b/etcd/src/test/scala/com/github/fit51/reactiveconfig/etcd/ReactiveConfigEtcdTest.scala
@@ -1,0 +1,58 @@
+package com.github.fit51.reactiveconfig.etcd
+
+import monix.eval.{Task, TaskLift}
+import cats.data.NonEmptySet
+import cats.implicits._
+import com.github.fit51.reactiveconfig.etcd.gen.kv.KeyValue
+import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.any
+import com.github.fit51.reactiveconfig.parser.ConfigParser
+import monix.reactive.Observable
+import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.util.Try
+import scala.concurrent.duration._
+
+//Does not work with Java 11, due to Mockito issue, use Java 8
+class ReactiveConfigEtcdTest extends WordSpecLike with Matchers with MockitoSugar {
+  import monix.execution.Scheduler.Implicits.global
+
+  trait ParsedData
+  implicit val configParser = new ConfigParser[ParsedData] {
+    override def parse(rawData: String): Try[ParsedData] = Try(???)
+  }
+  class EtcdClientTask(m: ChannelManager) extends EtcdClient[Task](m) with Watch[Task] {
+    override implicit def taskLift: TaskLift[Task] = implicitly[TaskLift[Task]]
+  }
+
+  val intersectPrefixes1 = NonEmptySet.of("", "any.other")
+  val intersectPrefixes2 = NonEmptySet.of("some.one", "some")
+
+  val okPrefixes1 = NonEmptySet.of("some", "other")
+  val okPrefixes2 = NonEmptySet.of("some.one", "some.two")
+
+  "ReactiveConfigEtcd" should {
+    "check prefixes" in {
+      ReactiveConfigEtcd.doIntersect(intersectPrefixes1) shouldBe true
+      ReactiveConfigEtcd.doIntersect(intersectPrefixes2) shouldBe true
+      ReactiveConfigEtcd.doIntersect(okPrefixes1) shouldBe false
+      ReactiveConfigEtcd.doIntersect(okPrefixes2) shouldBe false
+    }
+
+    "fail apply if prefixes intersect and vice versa" in {
+
+      val client = mock[EtcdClientTask]
+      when(client.getRecursiveSinceRevision(any(), any(), any())).thenReturn(Task.pure((Seq.empty[KeyValue], 0L)))
+      when(client.watch(any())).thenReturn(Task.pure(Observable.empty))
+
+      val etcdConfigFail =
+        ReactiveConfigEtcd[Task, ParsedData](client, intersectPrefixes1).redeem(_ => None, _ => Some(Unit))
+      etcdConfigFail.runSyncUnsafe(10 seconds) shouldBe None
+
+      val etcdConfigOk = ReactiveConfigEtcd[Task, ParsedData](client, okPrefixes1).redeem(_ => None, _ => Some(Unit))
+      etcdConfigOk.runSyncUnsafe(10 seconds) shouldBe Some(Unit)
+    }
+  }
+
+}

--- a/examples/src/test/scala/com/github/fit51/reactiveconfig/tests/EtcdConfigServiceTest.scala
+++ b/examples/src/test/scala/com/github/fit51/reactiveconfig/tests/EtcdConfigServiceTest.scala
@@ -1,6 +1,6 @@
 package com.github.fit51.reactiveconfig.tests
 
-import cats.data.NonEmptyList
+import cats.data.NonEmptySet
 import cats.implicits._
 import com.github.fit51.reactiveconfig.config.ReactiveConfig
 import com.github.fit51.reactiveconfig.etcd.{ChannelManager, EtcdClient, ReactiveConfigEtcd, Watch}
@@ -46,7 +46,7 @@ class EtcdConfigServiceTest extends WordSpecLike with Matchers with Eventually {
 
     for {
       _      <- data.traverse(kv => etcdClient.put(kv.k, kv.v))
-      config <- ReactiveConfigEtcd[Task, Json](etcdClient, NonEmptyList.apply("common", List("prefix1")))
+      config <- ReactiveConfigEtcd[Task, Json](etcdClient, NonEmptySet.of("common", "prefix1"))
       r1     <- config.reloadable[String]("common.key.prefix.key1")
       r2     <- config.reloadable[String]("prefix1.key.prefix.key2")
     } yield Init(etcdClient, config, r1, r2)

--- a/examples/src/test/scala/com/github/fit51/reactiveconfig/tests/EtcdConfigServiceTest.scala
+++ b/examples/src/test/scala/com/github/fit51/reactiveconfig/tests/EtcdConfigServiceTest.scala
@@ -1,0 +1,100 @@
+package com.github.fit51.reactiveconfig.tests
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import com.github.fit51.reactiveconfig.config.ReactiveConfig
+import com.github.fit51.reactiveconfig.etcd.{ChannelManager, EtcdClient, ReactiveConfigEtcd, Watch}
+import com.github.fit51.reactiveconfig.reloadable.Reloadable
+import io.circe.Json
+import monix.eval.{Task, TaskLift}
+import org.scalatest.{Matchers, WordSpecLike}
+import io.circe.parser._
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+  * This is service test, start etcd before running.
+  * Run docker command, it will start etcd on 127.0.0.1:2379 without authentication:
+  * sudo docker run -e ALLOW_NONE_AUTHENTICATION=yes -p 2379:2379 bitnami/etcd:latest
+  */
+class EtcdConfigServiceTest extends WordSpecLike with Matchers with Eventually {
+  import monix.execution.Scheduler.Implicits.global
+
+  case class KV(k: String, v: String)
+  implicit class AwaitTask[T](f: Task[T]) {
+    def get: T = Await.result(f.runToFuture, 10.minutes)
+  }
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 3.seconds)
+
+  case class Init(
+      client: EtcdClient[Task],
+      config: ReactiveConfig[Task, Json],
+      r1: Reloadable[Task, String],
+      r2: Reloadable[Task, String]
+  )
+
+  def init: Task[Init] = {
+    import com.github.fit51.reactiveconfig.parser.CirceConfigParser.parser
+    import com.github.fit51.reactiveconfig.parser.CirceConfigDecoder.decoder
+
+    val chManager = ChannelManager.noAuth("http://127.0.0.1:2379")
+    val etcdClient = new EtcdClient[Task](chManager) with Watch[Task] {
+      val taskLift = TaskLift[Task]
+    }
+
+    for {
+      _      <- data.traverse(kv => etcdClient.put(kv.k, kv.v))
+      config <- ReactiveConfigEtcd[Task, Json](etcdClient, NonEmptyList.apply("common", List("prefix1")))
+      r1     <- config.reloadable[String]("common.key.prefix.key1")
+      r2     <- config.reloadable[String]("prefix1.key.prefix.key2")
+    } yield Init(etcdClient, config, r1, r2)
+  }
+
+  def close(init: Init): Unit = {
+    init.client.close()
+  }
+
+  val data = List(
+    KV("common.key.prefix.key1", "\"v1\""),
+    KV("prefix1.key.prefix.key2", "\"v1\"")
+  )
+
+  val updates = List(
+    KV("common.key.prefix.key1", "\"v2\""),
+    KV("prefix1.key.prefix.key2", "\"v2\"")
+  )
+
+  val updates2 = List(
+    KV("prefix1.key.prefix.key2", "\"v3\""),
+    KV("common.key.prefix.key1", "\"v3\"")
+  )
+
+  def check(rl: List[Reloadable[Task, String]], v: List[KV]): Task[Boolean] = {
+    rl.zip(v)
+      .traverse {
+        case (r, kv) =>
+          r.get.map { v =>
+            println(s"Current value: $v")
+            v == parse(kv.v).getOrElse(Json.Null).as[String].getOrElse("")
+          }
+      }
+      .map(_.forall(_ == true))
+  }
+
+  "Reactive etcd config" should {
+    "subscriber on key changes on multiple prefixes" in {
+      val in = init.get
+      eventually { check(List(in.r1, in.r2), data).get shouldEqual true }
+
+      updates.traverse(kv => in.client.put(kv.k, kv.v)).get
+      eventually { check(List(in.r1, in.r2), updates).get shouldEqual true }
+
+      updates2.traverse(kv => in.client.put(kv.k, kv.v)).get
+      eventually { check(List(in.r1, in.r2), updates2).get shouldEqual true }
+
+      close(in)
+    }
+  }
+}

--- a/typesafe/src/test/scala/com/github/fit51/reactiveconfig/typesafe/TypesafeConfigStorageTest.scala
+++ b/typesafe/src/test/scala/com/github/fit51/reactiveconfig/typesafe/TypesafeConfigStorageTest.scala
@@ -52,35 +52,41 @@ class TypesafeConfigStorageTest extends WordSpecLike with Matchers with MockitoS
     "config should be able to reload primitive value on change" in new mocks {
       (for {
         reloadable <- config.reloadable[Int]("changeable.parameter.value")
-        first <- reloadable.get
+        first      <- reloadable.get
         _ <- IO.delay(
           File(path.getParent.resolve("changeable.conf")).overwrite(changeable(2))
         )
-        _ <- IO.sleep(300 millis)
+        _      <- IO.sleep(300 millis)
         second <- reloadable.get
       } yield {
         first shouldBe 1
         second shouldBe 2
-      }).guarantee(IO.delay(
-        File(path.getParent.resolve("changeable.conf")).overwrite(changeable(1))
-      )).unsafeRunSync()
+      }).guarantee(
+          IO.delay(
+            File(path.getParent.resolve("changeable.conf")).overwrite(changeable(1))
+          )
+        )
+        .unsafeRunSync()
     }
 
     "config should be able to reload case class on change" in new mocks {
       (for {
         reloadable <- config.reloadable[Parameter]("changeable.parameter")
-        first <- reloadable.get
+        first      <- reloadable.get
         _ <- IO.delay(
           File(path.getParent.resolve("changeable.conf")).overwrite(changeable(2))
         )
-        _ <- IO.sleep(300 millis)
+        _      <- IO.sleep(300 millis)
         second <- reloadable.get
       } yield {
         first shouldBe Parameter(1)
         second shouldBe Parameter(2)
-      }).guarantee(IO.delay(
-        File(path.getParent.resolve("changeable.conf")).overwrite(changeable(1))
-      )).unsafeRunSync()
+      }).guarantee(
+          IO.delay(
+            File(path.getParent.resolve("changeable.conf")).overwrite(changeable(1))
+          )
+        )
+        .unsafeRunSync()
     }
   }
 }


### PR DESCRIPTION
Here are the diffs of the PR:
1) Scalafmt formatting changes. (scalafmtOnCompile := true) It is strange that we had different formatting previously.
2) Added multiple Prefixes instead of one. Had to rewrite Watch to store Map of watchIds, and EtcdConfigStoraged. I merged watch-observables with default OverflowStrategy(1024 buffer)
3) I think it would be good to check if prefixes intersect and fail if they do. (in ReactiveConfigEtcd.apply). So we could eliminate duplicate updates.
Should I implement it, what do you think?

closes #9