### PR TITLE
Volatile & Reloadable.distinctByKey

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,18 @@
+val circeVersion = "0.12.3"
+
 lazy val commonSettings = Seq(
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.12.8", "2.13.1"),
+  scalaVersion := "2.12.10",
+  crossScalaVersions := Seq("2.12.10", "2.13.1"),
   libraryDependencies ++= Seq(
-    "io.monix"                   %% "monix"          % "3.0.0",
-    "org.typelevel"              %% "cats-effect"    % "2.0.0",
+    "io.monix"                   %% "monix"          % "3.1.0" % Provided,
+    "org.typelevel"              %% "cats-effect"    % "2.0.0" % Provided,
     "com.typesafe.scala-logging" %% "scala-logging"  % "3.9.2",
     "org.mockito"                % "mockito-core"    % "2.7.19" % Test,
     "org.scalatest"              %% "scalatest"      % "3.0.8" % Test,
     "ch.qos.logback"             % "logback-classic" % "1.2.3" % Test,
     "ch.qos.logback"             % "logback-core"    % "1.2.3" % Test,
-    "io.circe"                   %% "circe-generic"  % "0.12.2" % Test,
-    "org.slf4j"                  % "slf4j-api"       % "1.7.28" % Test
+    "io.circe"                   %% "circe-generic"  % circeVersion % Test,
+    "org.slf4j"                  % "slf4j-api"       % "1.7.25" % Test
   ),
   scalafmtOnCompile := true,
   resolvers += Resolver.sonatypeRepo("releases"),
@@ -32,7 +34,7 @@ lazy val circe = project
   .settings(
     name := "reactive-config-circe",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-parser" % "0.12.2"
+      "io.circe" %% "circe-parser" % circeVersion % Provided
     )
   )
 
@@ -75,7 +77,8 @@ lazy val typesafe = project
       "com.typesafe" % "config" % "1.3.1",
       //    TODO monix-nio is more convenient for our purposes but it uses Monix v 3.0.0-M3 which is incompatible with 3.0.0-RC2
       //    TODO better-files used instead. One should use monix-nio in future
-      "com.github.pathikrit" %% "better-files" % "3.8.0"
+      "com.github.pathikrit" %% "better-files" % "3.8.0",
+      "io.circe" %% "circe-parser" % circeVersion % Test
     )
   )
 
@@ -88,7 +91,7 @@ lazy val examples = project
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "ch.qos.logback" % "logback-core"    % "1.2.3",
-      "io.circe"       %% "circe-generic"  % "0.12.2"
+      "io.circe"       %% "circe-generic"  % circeVersion % Provided
     )
   )
 

--- a/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfig.scala
+++ b/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfig.scala
@@ -1,14 +1,35 @@
 package com.github.fit51.reactiveconfig.config
 
+import cats.~>
+import cats.MonadError
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 import com.github.fit51.reactiveconfig.reloadable.Reloadable
+import monix.eval.TaskLike
+import monix.eval.TaskLift
 
 import scala.util.Try
 
-trait ReactiveConfig[F[_], ParsedData] {
+trait ReactiveConfig[F[_], ParsedData] { self =>
   def unsafeGet[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): Try[T]
 
   def get[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): F[T]
 
   def reloadable[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): F[Reloadable[F, T]]
+
+  def mapK[G[_]: TaskLike: TaskLift: MonadError[?[_], Throwable]](transform: F ~> G): ReactiveConfig[G, ParsedData] =
+    new ReactiveConfig[G, ParsedData] {
+      override def unsafeGet[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): Try[T] =
+        self.unsafeGet(key)
+
+      override def get[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): G[T] =
+        transform(self.get(key))
+
+      override def reloadable[T](key: String)(implicit decoder: ConfigDecoder[T, ParsedData]): G[Reloadable[G, T]] =
+        for {
+          reloadableF <- transform(self.reloadable(key))
+          reloadableG <- reloadableF.mapK
+        } yield reloadableG
+    }
 }

--- a/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImpl.scala
+++ b/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImpl.scala
@@ -21,7 +21,7 @@ object ReactiveConfigImpl {
     **/
   def apply[F[_]: TaskLike: TaskLift, ParsedData](
       configStorage: ConfigStorage[F, ParsedData]
-  )(implicit s: Scheduler, F: MonadError[F, Throwable]): F[ReactiveConfigImpl[F, ParsedData]] =
+  )(implicit s: Scheduler, F: MonadError[F, Throwable]): F[ReactiveConfig[F, ParsedData]] =
     for {
       storage    <- configStorage.load()
       observable <- configStorage.watch()

--- a/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/EtcdConfigStorage.scala
+++ b/etcd/src/main/scala/com/github/fit51/reactiveconfig/etcd/EtcdConfigStorage.scala
@@ -1,7 +1,7 @@
 package com.github.fit51.reactiveconfig.etcd
 
 import cats.data.NonEmptySet
-import cats.effect.{Async, ContextShift}
+import cats.effect.Sync
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import monix.execution.Scheduler
@@ -20,14 +20,14 @@ object EtcdConfigStorage {
   /**
     * Creates new ConfigStorage for etcd fetching data wrapped in arbitrary F
     **/
-  def apply[F[_]: Async: ContextShift, Json](
+  def apply[F[_]: Sync, Json](
       etcd: EtcdClient[F] with Watch[F],
       prefixes: NonEmptySet[String]
   )(implicit s: Scheduler, encoder: ConfigParser[Json]): EtcdConfigStorage[F, Json] =
     new EtcdConfigStorage[F, Json](etcd, prefixes)
 }
 
-class EtcdConfigStorage[F[_]: Async: ContextShift, ParsedData](
+class EtcdConfigStorage[F[_]: Sync, ParsedData](
     etcd: EtcdClient[F] with Watch[F],
     prefixes: NonEmptySet[String]
 )(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.7
 sbt.gigahorse = false


### PR DESCRIPTION
1. Bump cats version
2. Add new method `Reloadable.distinctByKey` to filter out duplicated events
3. Add new trait `Volatile` which is simplified `Reloadable` but `Volatile` has method `mapK` which allows to change its context. This method can not be implemented on `Reloadable` because effect `F` is contained in both covariant and contravariant positions. `Volatile` has simpler interface with `F` only in covariant position.