### PR TITLE
Add logging of updated keys

### DIFF
--- a/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImpl.scala
+++ b/core/src/main/scala/com/github/fit51/reactiveconfig/config/ReactiveConfigImpl.scala
@@ -53,6 +53,6 @@ class ReactiveConfigImpl[F[_], ParsedData](
         .filter(_.key == key)
         .map(kv => decoder.decode(kv.value.parsedData))
         .collect { case Success(v) => v }
-      result <- Reloadable(initial, observable)
+      result <- Reloadable(initial, observable, key.some)
     } yield result
 }


### PR DESCRIPTION
Resolve #16 

Logging key names is enough. Values can contain sensitive data, so they cannot be logged