### PR TITLE
Run TypesafeConfigStorage on blocker pool

### DIFF
--- a/examples/src/main/scala/com/github/fit51/reactiveconfig/examples/TypesafeConfigApplication.scala
+++ b/examples/src/main/scala/com/github/fit51/reactiveconfig/examples/TypesafeConfigApplication.scala
@@ -3,6 +3,7 @@ package com.github.fit51.reactiveconfig.examples
 import java.nio.file.Paths
 
 import monix.eval.Task
+import cats.effect.Blocker
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.generic.auto._
@@ -17,6 +18,7 @@ case class SimpleLib(foo: String, whatever: String)
 
 object TypesafeConfigApplication extends App with LazyLogging {
   implicit val scheduler = monix.execution.Scheduler.global
+  val blocker            = Blocker.liftExecutionContext(monix.execution.Scheduler.io())
 
   import CirceConfigParser._
   import CirceConfigDecoder._
@@ -45,7 +47,7 @@ object TypesafeConfigApplication extends App with LazyLogging {
     } yield ()
 
   val app = for {
-    storage <- Task.eval(TypesafeConfigStorage[Task, Json](Paths.get("examples/config/application.conf")))
+    storage <- Task.eval(TypesafeConfigStorage[Task, Json](Paths.get("examples/config/application.conf"), blocker))
     config  <- ReactiveConfigImpl[Task, Json](storage)
     _       <- Task.eval(println("Now change examples/config/application.conf file and see what happens!"))
     fiber   <- useConfig(config).start

--- a/typesafe/src/main/scala/com/github/fit51/reactiveconfig/typesafe/FileWatch.scala
+++ b/typesafe/src/main/scala/com/github/fit51/reactiveconfig/typesafe/FileWatch.scala
@@ -1,15 +1,18 @@
 package com.github.fit51.reactiveconfig.typesafe
 
 import java.nio.file.{Path, WatchEvent, StandardWatchEventKinds => EventType}
+
+import cats.effect.Blocker
 import better.files.{File, FileMonitor}
-import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.PublishSubject
 
 object FileWatch {
 
-  def watch(file: File, output: PublishSubject[WatchEvent.Kind[Path]])(
-      implicit s: Scheduler
+  def watch(
+      file: File,
+      output: PublishSubject[WatchEvent.Kind[Path]],
+      blocker: Blocker
   ): Observable[WatchEvent.Kind[Path]] = {
     val monitor = new FileMonitor(file) {
       override def onEvent(eventType: WatchEvent.Kind[Path], file: File, count: Int): Unit = eventType match {
@@ -18,7 +21,7 @@ object FileWatch {
         case EventType.ENTRY_DELETE => output.onNext(EventType.ENTRY_DELETE)
       }
     }
-    monitor.start()
+    monitor.start()(blocker.blockingContext)
     output
   }
 }

--- a/typesafe/src/test/scala/com/github/fit51/reactiveconfig/typesafe/TypesafeConfigStorageTest.scala
+++ b/typesafe/src/test/scala/com/github/fit51/reactiveconfig/typesafe/TypesafeConfigStorageTest.scala
@@ -1,6 +1,7 @@
 package com.github.fit51.reactiveconfig.typesafe
 
 import better.files.File
+import cats.effect.Blocker
 import cats.effect.Clock
 import cats.effect.IO
 import com.github.fit51.reactiveconfig.config.ReactiveConfigImpl
@@ -8,6 +9,7 @@ import io.circe.generic.auto._
 import io.circe.Json
 import java.nio.file.Paths
 import monix.eval.Task
+import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.mockito.MockitoSugar
@@ -23,7 +25,7 @@ class TypesafeConfigStorageTest extends WordSpecLike with Matchers with MockitoS
 
   trait mocks {
     val path    = Paths.get("typesafe/src/test/resources/application.conf")
-    val storage = TypesafeConfigStorage[IO, Json](path)
+    val storage = TypesafeConfigStorage[IO, Json](path, Blocker.liftExecutionContext(Scheduler.io()))
     val config  = Await.result(ReactiveConfigImpl[IO, Json](storage).unsafeToFuture, 1 second)
 
     implicit val timer = new cats.effect.Timer[IO] {


### PR DESCRIPTION
Library better-files does blocking operations. So it will be better if we mark these operations explicitly by requiring `cats.effect.Blocker`.