### PR TITLE
ZIO 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,30 @@
 # reactive-config
 
-reactive-config is a configuration library for Scala. 
+reactive-config is a configuration library for Scala.
 
-It provides functionality to get pieces of config, that reload. 
-The piece of configuration is called `Reloadable`. 
+It provides functionality to get pieces of config, that reload.
+The piece of configuration is called `Reloadable`.
 You can `combine` and `map` `Reloadables` to construct change-propagation graphs.
 
-Library is implemented on top of [Monix](https://github.com/monix/monix) Observable and supports number of configuration back ends:
-* [Typesafe-config](https://github.com/lightbend/config) - HOCON file.  
-See [reactive-config-typesafe](https://github.com/fit51/reactive-config/tree/master/typesafe/src)
-* [Etcd](https://coreos.com/etcd/) - Distributed reliable key-value store, that supports monitoring changes to keys.  
-See [reactive-config-etcd]()
+Library is implemented for both ZIO and cats-effect stacks and supports number of configuration back ends:
+* [Typesafe-config](https://github.com/lightbend/config) - HOCON file
+See [typesafe-ce](https://github.com/fit51/reactive-config/tree/master/typesafe-ce) or [typesafe-zio](https://github.com/fit51/reactive-config/tree/master/typesafe-zio)
+* [Etcd](https://coreos.com/etcd/) - Distributed reliable key-value store, that supports monitoring changes to keys.
+See [etcd-ce](https://github.com/fit51/reactive-config/tree/master/etcd-ce) or [etcd-zio](https://github.com/fit51/reactive-config/tree/master/etcd-zio)
 
 ## Quickstart with sbt
 
 ```scala
 libraryDependencies ++= Seq(
-    "com.github.fit51" %% "reactive-config-circe" % "0.1.0-alpha2",
-    "com.github.fit51" %% "reactive-config-etcd"  % "0.1.0-alpha2"
+    "com.github.fit51" %% "reactiveconfig-circe" % version
+    "com.github.fit51" %% "reactiveconfig-etcd-zio" % version,
+    "com.github.fit51" %% "reactiveconfig-typesafe-zio" % version
 )
 ```
 
 ## Examples
 See examples [here](https://github.com/fit51/reactive-config/tree/master/examples).
 
-## Etcd
-Run "sbt etcd/generateSources" to generate etcd GRPC services and move them to source directory.
-
 ## Note
-Library is in development.  
-It was originally created in private Bitbucket repository. Now, library is moved to GitHub with most of commits squashed due to _some_ reasons. 
+Library is in development.
+It was originally created in private Bitbucket repository. Now, library is moved to GitHub with most of commits squashed due to _some_ reasons.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val circeVersion = "0.14.1"
 val logbackVersion = "1.4.5"
 
-val scala212 = "2.12.14"
+val scala212 = "2.12.17"
 val scala213 = "2.13.8"
 val allScalaVersions = List(scala212, scala213)
 
@@ -10,6 +10,7 @@ val scalaTestContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % "
 
 lazy val commonSettings = Seq(
   scalaVersion := scala213,
+  crossScalaVersions := allScalaVersions,
   scalacOptions ++= List(
     "-feature",
     "-unchecked",
@@ -29,31 +30,35 @@ lazy val commonSettings = Seq(
   scalafmtOnCompile := true,
   resolvers += Resolver.sonatypeRepo("releases"),
   addCompilerPlugin("org.typelevel" % "kind-projector"      % "0.13.2" cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
+  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
+  libraryDependencies ++= (
+    if (CrossVersion.partialVersion(scalaVersion.value).contains((2, 12))) {
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+    } else {
+      Nil
+    }
+  )
 )
 
-lazy val `reactiveconfig-core` = projectMatrix
+lazy val `reactiveconfig-core` = project
   .in(file("core"))
   .settings(commonSettings)
   .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
   .settings(libraryDependencies += "org.typelevel" %% "cats-core" % "2.7.0")
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-core-zio` = projectMatrix
+lazy val `reactiveconfig-core-zio` = project
   .in(file("core-zio"))
   .settings(commonSettings)
   .settings(libraryDependencies += "dev.zio" %% "zio" % "2.0.6")
   .dependsOn(`reactiveconfig-core` % "compile->compile;test->test")
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-core-ce` = projectMatrix
+lazy val `reactiveconfig-core-ce` = project
   .in(file("core-ce"))
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(scalaLogging, "org.typelevel" %% "cats-effect" % "2.5.4"))
   .dependsOn(`reactiveconfig-core` % "compile->compile;test->test")
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-circe` = projectMatrix
+lazy val `reactiveconfig-circe` = project
   .in(file("circe"))
   .dependsOn(`reactiveconfig-core`)
   .settings(commonSettings)
@@ -62,9 +67,8 @@ lazy val `reactiveconfig-circe` = projectMatrix
     "io.circe" %% "circe-parser" % circeVersion % Provided,
     "io.circe" %% "circe-generic" % circeVersion % Test
   ))
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-etcd` = projectMatrix
+lazy val `reactiveconfig-etcd` = project
   .in(file("etcd"))
   .dependsOn(`reactiveconfig-core`)
   .settings(commonSettings)
@@ -82,45 +86,41 @@ lazy val `reactiveconfig-etcd` = projectMatrix
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
     )
   )
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-etcd-ce` = projectMatrix
+lazy val `reactiveconfig-etcd-ce` = project
   .in(file("etcd-ce"))
   .dependsOn(`reactiveconfig-core-ce`, `reactiveconfig-etcd`)
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(scalaTestContainers))
   .settings(
     Compile / PB.protoSources := Seq(
-      (`reactiveconfig-etcd`.jvm(scala213) / Compile / sourceDirectory).value / "protobuf"
+      (`reactiveconfig-etcd` / Compile / sourceDirectory).value / "protobuf"
     )
   )
   .enablePlugins(Fs2Grpc)
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-etcd-zio` = projectMatrix
+lazy val `reactiveconfig-etcd-zio` = project
   .in(file("etcd-zio"))
   .dependsOn(`reactiveconfig-core-zio`, `reactiveconfig-etcd`)
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(scalaTestContainers))
   .settings(
     Compile / PB.protoSources := Seq(
-      (`reactiveconfig-etcd`.jvm(scala213) / Compile / sourceDirectory).value / "protobuf"
+      (`reactiveconfig-etcd` / Compile / sourceDirectory).value / "protobuf"
     ),
     Compile / PB.targets := Seq(
       scalapb.gen(grpc = true) -> (Compile / sourceManaged).value,
       scalapb.zio_grpc.ZioCodeGenerator -> (Compile / sourceManaged).value / "scalapb"
     )
   )
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-typesafe` = projectMatrix
+lazy val `reactiveconfig-typesafe` = project
   .in(file("typesafe"))
   .settings(commonSettings)
   .settings(libraryDependencies += "com.typesafe" % "config" % "1.4.2")
   .dependsOn(`reactiveconfig-core`)
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-typesafe-ce` = projectMatrix
+lazy val `reactiveconfig-typesafe-ce` = project
   .in(file("typesafe-ce"))
   .settings(commonSettings)
   .dependsOn(`reactiveconfig-core-ce`, `reactiveconfig-typesafe`)
@@ -128,9 +128,8 @@ lazy val `reactiveconfig-typesafe-ce` = projectMatrix
     "co.fs2" %% "fs2-io" % "2.5.9",
     "io.circe" %% "circe-parser" % circeVersion % Test
   ))
- .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `reactiveconfig-typesafe-zio` = projectMatrix
+lazy val `reactiveconfig-typesafe-zio` = project
   .in(file("typesafe-zio"))
   .settings(commonSettings)
   .dependsOn(`reactiveconfig-core-zio`, `reactiveconfig-typesafe`)
@@ -138,9 +137,8 @@ lazy val `reactiveconfig-typesafe-zio` = projectMatrix
     "dev.zio" %% "zio-nio" % "2.0.0",
     "io.circe" %% "circe-parser" % circeVersion % Test
   ))
-  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val examples = projectMatrix
+lazy val examples = project
   .in(file("examples"))
   .settings(commonSettings)
   .dependsOn(`reactiveconfig-etcd-ce`, `reactiveconfig-typesafe-ce`, `reactiveconfig-circe`)
@@ -151,7 +149,6 @@ lazy val examples = projectMatrix
       "ch.qos.logback" % "logback-classic" % logbackVersion,
       "ch.qos.logback" % "logback-core"    % logbackVersion,
       "io.circe"       %% "circe-generic"  % circeVersion,
-      "io.circe"       %% "circe-parser"  % circeVersion
+      "io.circe"       %% "circe-parser"   % circeVersion
     )
   )
-  .jvmPlatform(scalaVersions = allScalaVersions)

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val scala212 = "2.12.14"
 val scala213 = "2.13.8"
 val allScalaVersions = List(scala212, scala213)
 
+val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 val scalaTestContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.40.11" % Test
 
 lazy val commonSettings = Seq(
@@ -22,7 +23,6 @@ lazy val commonSettings = Seq(
     case _ => throw new Exception("!")
   }),
   libraryDependencies ++= Seq(
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
     "org.mockito"                % "mockito-core"   % "3.7.7" % Test,
     "org.scalatest"              %% "scalatest"     % "3.0.8" % Test
   ),
@@ -35,20 +35,21 @@ lazy val commonSettings = Seq(
 lazy val `reactiveconfig-core` = projectMatrix
   .in(file("core"))
   .settings(commonSettings)
+  .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
   .settings(libraryDependencies += "org.typelevel" %% "cats-core" % "2.7.0")
   .jvmPlatform(scalaVersions = allScalaVersions)
 
 lazy val `reactiveconfig-core-zio` = projectMatrix
   .in(file("core-zio"))
   .settings(commonSettings)
-  .settings(libraryDependencies += "dev.zio" %% "zio" % "1.0.13")
+  .settings(libraryDependencies += "dev.zio" %% "zio" % "2.0.6")
   .dependsOn(`reactiveconfig-core` % "compile->compile;test->test")
   .jvmPlatform(scalaVersions = allScalaVersions)
 
 lazy val `reactiveconfig-core-ce` = projectMatrix
   .in(file("core-ce"))
   .settings(commonSettings)
-  .settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "2.5.4")
+  .settings(libraryDependencies ++= List(scalaLogging, "org.typelevel" %% "cats-effect" % "2.5.4"))
   .dependsOn(`reactiveconfig-core` % "compile->compile;test->test")
   .jvmPlatform(scalaVersions = allScalaVersions)
 
@@ -57,6 +58,7 @@ lazy val `reactiveconfig-circe` = projectMatrix
   .dependsOn(`reactiveconfig-core`)
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(
+    scalaLogging,
     "io.circe" %% "circe-parser" % circeVersion % Provided,
     "io.circe" %% "circe-generic" % circeVersion % Test
   ))
@@ -67,6 +69,7 @@ lazy val `reactiveconfig-etcd` = projectMatrix
   .dependsOn(`reactiveconfig-core`)
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(
+    scalaLogging,
     "io.grpc" % "grpc-netty" % "1.43.2",
     "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
     "com.pauldijou" %% "jwt-core" % "4.3.0"
@@ -132,7 +135,7 @@ lazy val `reactiveconfig-typesafe-zio` = projectMatrix
   .settings(commonSettings)
   .dependsOn(`reactiveconfig-core-zio`, `reactiveconfig-typesafe`)
   .settings(libraryDependencies ++= List(
-    "dev.zio" %% "zio-nio" % "1.0.0-RC12",
+    "dev.zio" %% "zio-nio" % "2.0.0",
     "io.circe" %% "circe-parser" % circeVersion % Test
   ))
   .jvmPlatform(scalaVersions = allScalaVersions)

--- a/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/generic/ReloadableMacro.scala
+++ b/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/generic/ReloadableMacro.scala
@@ -6,6 +6,7 @@ import com.github.fit51.reactiveconfig.Sensitive
 import com.github.fit51.reactiveconfig.ce.config.ReactiveConfig
 import com.github.fit51.reactiveconfig.ce.reloadable.Reloadable
 import com.github.fit51.reactiveconfig.generic.CommonReloadableMacro
+import com.github.fit51.reactiveconfig.generic.Configuration
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 
 import scala.reflect.macros.whitebox
@@ -15,23 +16,32 @@ class ReloadableMacro(override val c: whitebox.Context) extends CommonReloadable
 
   def reloadableImpl0[F[_], D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[F, D]]
-  )(F: c.Expr[Concurrent[F]], P: c.Expr[Parallel[F]]): c.Expr[Resource[F, Reloadable[F, A]]] =
-    reloadableImpl1[F, D, A](config, c.Expr[String](q"$emptyString"))(F, P)
+  )(
+      F: c.Expr[Concurrent[F]],
+      P: c.Expr[Parallel[F]],
+      cfg: c.Expr[Configuration]
+  ): c.Expr[Resource[F, Reloadable[F, A]]] =
+    reloadableImpl1[F, D, A](config, c.Expr[String](q"$emptyString"))(F, P, cfg)
 
   def reloadableImpl1[F[_], D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[F, D]],
       prefix: c.Expr[String]
-  )(F: c.Expr[Concurrent[F]], P: c.Expr[Parallel[F]]): c.Expr[Resource[F, Reloadable[F, A]]] =
-    reloadableImpl[F, D, A](config, prefix, false)
+  )(
+      F: c.Expr[Concurrent[F]],
+      P: c.Expr[Parallel[F]],
+      cfg: c.Expr[Configuration]
+  ): c.Expr[Resource[F, Reloadable[F, A]]] =
+    reloadableImpl[F, D, A](config, prefix, cfg, false)
 
   def reloadableImpl2[F[_], D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[F, D]]
   )(
       decoder: c.Expr[ConfigDecoder[Sensitive, D]],
       F: c.Expr[Concurrent[F]],
-      P: c.Expr[Parallel[F]]
+      P: c.Expr[Parallel[F]],
+      cfg: c.Expr[Configuration]
   ): c.Expr[Resource[F, Reloadable[F, A]]] =
-    reloadableImpl3[F, D, A](config, c.Expr[String](q"$emptyString"))(decoder, F, P)
+    reloadableImpl3[F, D, A](config, c.Expr[String](q"$emptyString"))(decoder, F, P, cfg)
 
   def reloadableImpl3[F[_], D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[F, D]],
@@ -39,20 +49,22 @@ class ReloadableMacro(override val c: whitebox.Context) extends CommonReloadable
   )(
       decoder: c.Expr[ConfigDecoder[Sensitive, D]],
       F: c.Expr[Concurrent[F]],
-      P: c.Expr[Parallel[F]]
+      P: c.Expr[Parallel[F]],
+      cfg: c.Expr[Configuration]
   ): c.Expr[Resource[F, Reloadable[F, A]]] =
-    reloadableImpl[F, D, A](config, prefix, true)
+    reloadableImpl[F, D, A](config, prefix, cfg, true)
 
   def reloadableImpl[F[_], D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[F, D]],
       prefix: c.Expr[String],
+      cfg: c.Expr[Configuration],
       sensitive: Boolean
   ): c.Expr[Resource[F, Reloadable[F, A]]] = {
     val classSymbol   = ensureCaseClass[A]
     val annotations   = extractConstructorAnnotations(classSymbol)
     val prefixLiteral = extractPrefixLiteral(prefix)
     c.Expr[Resource[F, Reloadable[F, A]]](
-      reloadableDefs(weakTypeOf[D], prefixLiteral, classSymbol.asType.name, annotations)
+      reloadableDefs(weakTypeOf[D], prefixLiteral, classSymbol.asType.name, annotations, cfg)
     )
   }
 

--- a/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/generic/package.scala
+++ b/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/generic/package.scala
@@ -5,6 +5,7 @@ import cats.effect.{Concurrent, Resource}
 import com.github.fit51.reactiveconfig.Sensitive
 import com.github.fit51.reactiveconfig.ce.config.ReactiveConfig
 import com.github.fit51.reactiveconfig.ce.reloadable.Reloadable
+import com.github.fit51.reactiveconfig.generic.Configuration
 import com.github.fit51.reactiveconfig.generic.RootReactiveConfig
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 
@@ -15,13 +16,13 @@ package object generic {
 
   def deriveReloadable[F[_], D, A](
       config: ReactiveConfig[F, D]
-  )(implicit F: Concurrent[F], P: Parallel[F]): Resource[F, Reloadable[F, A]] =
+  )(implicit F: Concurrent[F], P: Parallel[F], cfg: Configuration): Resource[F, Reloadable[F, A]] =
     macro ReloadableMacro.reloadableImpl0[F, D, A]
 
   def deriveReloadable[F[_], D, A](
       config: ReactiveConfig[F, D],
       prefix: String
-  )(implicit F: Concurrent[F], P: Parallel[F]): Resource[F, Reloadable[F, A]] =
+  )(implicit F: Concurrent[F], P: Parallel[F], cfg: Configuration): Resource[F, Reloadable[F, A]] =
     macro ReloadableMacro.reloadableImpl1[F, D, A]
 
   def deriveSensitiveReloadable[F[_], D, A](
@@ -29,7 +30,8 @@ package object generic {
   )(implicit
       decoder: ConfigDecoder[Sensitive, D],
       F: Concurrent[F],
-      P: Parallel[F]
+      P: Parallel[F],
+      cfg: Configuration
   ): Resource[F, Reloadable[F, A]] =
     macro ReloadableMacro.reloadableImpl2[F, D, A]
 
@@ -39,7 +41,8 @@ package object generic {
   )(implicit
       decoder: ConfigDecoder[Sensitive, D],
       F: Concurrent[F],
-      P: Parallel[F]
+      P: Parallel[F],
+      cfg: Configuration
   ): Resource[F, Reloadable[F, A]] =
     macro ReloadableMacro.reloadableImpl3[F, D, A]
 

--- a/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/instances/CatsEffectInstances.scala
+++ b/core-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/instances/CatsEffectInstances.scala
@@ -76,7 +76,7 @@ trait CatsEffectInstances extends StrictLogging {
         ra.flatMap(f)
     }
 
-  implicit def applicativeForEffect[F[_]](implicit effect: Effect[F]): Applicative[F] =
+  def applicativeForEffect[F[_]](implicit effect: Effect[F]): Applicative[F] =
     new Applicative[F] {
 
       override def ap[A, B](ff: F[A => B])(fa: F[A]): F[B] =

--- a/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/AnnotationTest.scala
+++ b/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/AnnotationTest.scala
@@ -54,7 +54,8 @@ class ReactiveConfigMacroTest extends WordSpecLike with Matchers {
         "enormous.field28"           -> "28",
         "enormous.field29"           -> "29",
         "prefix.booleanFlag"         -> "true",
-        "prefix.creds"               -> "user:pass"
+        "prefix.creds"               -> "user:pass",
+        "prefix.snake_case"          -> "string"
       )
     )
 
@@ -79,12 +80,12 @@ class ReactiveConfigMacroTest extends WordSpecLike with Matchers {
     }
 
     "generate Reloadable for sensitive class" in {
-      val expected = Config(SensitiveConfig("user", Sensitive("passpass")), true)
+      val expected = Config(SensitiveConfig("user", Sensitive("passpass")), true, "string")
       Config.reloadable[IO](config).use(_.get).unsafeRunSync() shouldBe expected
     }
 
     "generate Volatile for sensitive class" in {
-      val expected = Config(SensitiveConfig("user", Sensitive("passpass")), true)
+      val expected = Config(SensitiveConfig("user", Sensitive("passpass")), true, "string")
       Config.volatile[IO, cats.Id](config).use(r => IO.delay(r.get)).unsafeRunSync() shouldBe expected
     }
 
@@ -129,7 +130,8 @@ final case class Config(
     @source("creds")
     credentials: SensitiveConfig,
     @source("booleanFlag")
-    anotherFlag: Boolean
+    anotherFlag: Boolean,
+    snakeCase: String
 )
 
 object Config {
@@ -155,7 +157,6 @@ trait NotSealedTrait2 {
 final case class NotSoPlain2(
     @source("field1")
     override val field1: Int,
-    @source("field2")
     override val field2: Boolean,
     @source("//completely.different.field")
     field3: Double
@@ -174,12 +175,12 @@ final case class Enormous2(
     @source("field2") field2: Int,
     @source("field3") field3: Int,
     @source("field4") field4: Int,
-    @source("field5") field5: Boolean,
+    field5: Boolean,
     @source("field6") field6: Int,
     @source("field7") field7: Int,
     @source("field8") field8: Int,
     @source("field9") field9: Int,
-    @source("field10") field10: Int,
+    field10: Int,
     @source("field11") field11: Int,
     @source("field12") field12: Int,
     @source("field13") field13: Int,
@@ -193,7 +194,7 @@ final case class Enormous2(
     @source("field21") field21: Int,
     @source("field22") field22: Int,
     @source("field23") field23: Int,
-    @source("field24") field24: Int,
+    field24: Int,
     @source("field25") field25: Int,
     @source("field26") field26: Int,
     @source("field27") field27: Int,

--- a/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/MacroTest.scala
+++ b/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/MacroTest.scala
@@ -271,5 +271,10 @@ object WithSensitiveField {
   def reloadable[F[_]: Concurrent: Parallel](config: ReactiveConfig[F, String])(implicit
       decoder: ConfigDecoder[Sensitive, String]
   ) =
-    deriveSensitiveReloadable[F, String, WithSensitiveField](config)(sensitiveDecoder, implicitly, implicitly)
+    deriveSensitiveReloadable[F, String, WithSensitiveField](config)(
+      sensitiveDecoder,
+      implicitly,
+      implicitly,
+      implicitly
+    )
 }

--- a/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/instances.scala
+++ b/core-ce/src/test/scala/com/github/fit51/reactiveconfig/ce/generic/instances.scala
@@ -2,6 +2,7 @@ package com.github.fit51.reactiveconfig.ce.generic
 
 import cats.effect.{ContextShift, IO}
 import com.github.fit51.reactiveconfig.Sensitive
+import com.github.fit51.reactiveconfig.generic.Configuration
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 
 import scala.concurrent.ExecutionContext
@@ -18,6 +19,9 @@ object Decoders {
   implicit val doubleDecoder: ConfigDecoder[Double, String] =
     s => Try(s.toDouble)
 
+  implicit val stringDecoder: ConfigDecoder[String, String] =
+    ConfigDecoder.identity
+
   val sensitiveDecoder: ConfigDecoder[Sensitive, String] =
     s => Success(Sensitive(s * 2))
 
@@ -26,6 +30,9 @@ object Decoders {
       val Array(rawInt, rawBoolean, rawDouble) = s.split(":")
       Success(Plain(rawInt.toInt, rawBoolean.toBoolean, rawDouble.toDouble))
     }
+
+  implicit val reactiveConfigConfiguration: Configuration =
+    Configuration.default.withSnakeCaseMemberNames
 }
 
 object instances {

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/config/AbstractReactiveConfig.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/config/AbstractReactiveConfig.scala
@@ -6,7 +6,7 @@ import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 import com.github.fit51.reactiveconfig.zio.reloadable.Reloadable
 import zio._
 
-class AbstractReactiveConfig[D](stateRef: RefM[ConfigState[UIO, D]]) extends ReactiveConfig[D] {
+class AbstractReactiveConfig[D](stateRef: Ref.Synchronized[ConfigState[UIO, D]]) extends ReactiveConfig[D] {
 
   override def get[T](key: String)(implicit decoder: ConfigDecoder[T, D]): IO[ReactiveConfigException, T] =
     stateRef.get.flatMap { state =>
@@ -18,18 +18,15 @@ class AbstractReactiveConfig[D](stateRef: RefM[ConfigState[UIO, D]]) extends Rea
 
   override def reloadable[T](
       key: String
-  )(implicit decoder: ConfigDecoder[T, D]): Managed[ReactiveConfigException, Reloadable[T]] =
-    ZManaged((for {
-      env <- ZIO.environment[(Any, ZManaged.ReleaseMap)]
-      (reloadable, newFinalizer) <- stateRef.modify { state =>
+  )(implicit decoder: ConfigDecoder[T, D]): ZIO[Scope, ReactiveConfigException, Reloadable[T]] =
+    ZIO.scopeWith { scope =>
+      stateRef.modifyZIO { state =>
         for {
-          initial                            <- ZIO.fromEither(state.extractValue(key))
-          (finalizer, (reloadable, updater)) <- Reloadable.root(initial).zio.provide(env)
+          initial               <- ZIO.fromEither(state.extractValue(key))
+          (reloadable, updater) <- Reloadable.root(initial)
           listener = Listener(decoder, updater)
-          newFinalizer <- env._2.add { exit =>
-            finalizer(exit) *> stateRef.update(state => UIO.succeed(state.removeListener(key, listener)))
-          }
-        } yield ((reloadable, newFinalizer), state.addListener(key, listener))
-      }
-    } yield (newFinalizer, reloadable)).uninterruptible)
+          _ <- scope.addFinalizer(ZIO.succeed(state.removeListener(key, listener)))
+        } yield (reloadable, state.addListener(key, listener))
+      }.uninterruptible
+    }
 }

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReactiveConfigAnnotation.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReactiveConfigAnnotation.scala
@@ -14,23 +14,41 @@ class ReactiveConfigAnnotation(override val c: whitebox.Context) extends CommonC
         import com.github.fit51.reactiveconfig.ReactiveConfigException
         import com.github.fit51.reactiveconfig.zio.config.ReactiveConfig
         import com.github.fit51.reactiveconfig.zio.reloadable.Reloadable
-        import zio.Managed
+        import zio.{Scope, ZIO, ZLayer}
       """
     if (sensitive) {
       q"""
         ..$imports
         import com.github.fit51.reactiveconfig.Sensitive
         import com.github.fit51.reactiveconfig.parser.ConfigDecoder
+        import zio.&
 
-        def reloadable(config: ReactiveConfig[$dataType])(implicit d: ConfigDecoder[Sensitive, $dataType]): Managed[ReactiveConfigException, Reloadable[$name]] =
+        def reloadable(config: ReactiveConfig[$dataType])(implicit d: ConfigDecoder[Sensitive, $dataType]): ZIO[Scope, ReactiveConfigException, Reloadable[$name]] =
           com.github.fit51.reactiveconfig.zio.generic.deriveSensitiveReloadable[$dataType, $name](config, $prefix)
+
+        val layer: ZLayer[ReactiveConfig[$dataType] & ConfigDecoder[Sensitive, $dataType], ReactiveConfigException, Reloadable[$name]] =
+          ZLayer.scoped {
+            for {
+              config <- ZIO.service[ReactiveConfig[$dataType]]
+              decoder <- ZIO.service[ConfigDecoder[Sensitive, $dataType]]
+              result <- reloadable(config)(decoder)
+            } yield result
+          }
       """
     } else {
       q"""
         ..$imports
 
-        def reloadable(config: ReactiveConfig[$dataType]): Managed[ReactiveConfigException, Reloadable[$name]] =
+        def reloadable(config: ReactiveConfig[$dataType]): ZIO[Scope, ReactiveConfigException, Reloadable[$name]] =
           com.github.fit51.reactiveconfig.zio.generic.deriveReloadable[$dataType, $name](config, $prefix)
+
+        val layer: ZLayer[ReactiveConfig[$dataType], ReactiveConfigException, Reloadable[$name]] =
+          ZLayer.scoped {
+            for {
+              config <- ZIO.service[ReactiveConfig[$dataType]]
+              result <- reloadable(config)
+            } yield result
+          }
       """
     }
   }

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReloadableMacro.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReloadableMacro.scala
@@ -2,6 +2,7 @@ package com.github.fit51.reactiveconfig.zio.generic
 
 import com.github.fit51.reactiveconfig.{ReactiveConfigException, Sensitive}
 import com.github.fit51.reactiveconfig.generic.CommonReloadableMacro
+import com.github.fit51.reactiveconfig.generic.Configuration
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 import com.github.fit51.reactiveconfig.zio.config.ReactiveConfig
 import com.github.fit51.reactiveconfig.zio.reloadable.Reloadable
@@ -14,36 +15,43 @@ class ReloadableMacro(override val c: whitebox.Context) extends CommonReloadable
 
   def reloadableImpl0[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]]
-  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
-    reloadableImpl1[D, A](config, c.Expr[String](q"$emptyString"))
+  )(cfg: c.Expr[Configuration]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
+    reloadableImpl1[D, A](config, c.Expr[String](q"$emptyString"))(cfg)
 
   def reloadableImpl1[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String]
-  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
-    reloadableImpl[D, A](config, prefix, false)
+  )(cfg: c.Expr[Configuration]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
+    reloadableImpl[D, A](config, prefix, cfg, false)
 
   def reloadableImpl2[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]]
-  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
-    reloadableImpl3[D, A](config, c.Expr[String](q"$emptyString"))(decoder)
+  )(
+      decoder: c.Expr[ConfigDecoder[Sensitive, D]],
+      cfg: c.Expr[Configuration]
+  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
+    reloadableImpl3[D, A](config, c.Expr[String](q"$emptyString"))(decoder, cfg)
 
   def reloadableImpl3[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String]
-  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
-    reloadableImpl[D, A](config, prefix, true)
+  )(
+      decoder: c.Expr[ConfigDecoder[Sensitive, D]],
+      cfg: c.Expr[Configuration]
+  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
+    reloadableImpl[D, A](config, prefix, cfg, true)
 
   def reloadableImpl[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String],
+      cfg: c.Expr[Configuration],
       sensitive: Boolean
   ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] = {
     val classSymbol   = ensureCaseClass[A]
     val annotations   = extractConstructorAnnotations(classSymbol)
     val prefixLiteral = extractPrefixLiteral(prefix)
     c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]](
-      reloadableDefs(weakTypeOf[D], prefixLiteral, classSymbol.asType.name, annotations)
+      reloadableDefs(weakTypeOf[D], prefixLiteral, classSymbol.asType.name, annotations, cfg)
     )
   }
 

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReloadableMacro.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/ReloadableMacro.scala
@@ -10,39 +10,39 @@ import zio._
 import scala.reflect.macros.whitebox
 
 class ReloadableMacro(override val c: whitebox.Context) extends CommonReloadableMacro(c) {
-  import c.universe._
+  import c.universe.{Scope => _, _}
 
   def reloadableImpl0[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]]
-  ): c.Expr[Managed[ReactiveConfigException, Reloadable[A]]] =
+  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
     reloadableImpl1[D, A](config, c.Expr[String](q"$emptyString"))
 
   def reloadableImpl1[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String]
-  ): c.Expr[Managed[ReactiveConfigException, Reloadable[A]]] =
+  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
     reloadableImpl[D, A](config, prefix, false)
 
   def reloadableImpl2[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]]
-  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[Managed[ReactiveConfigException, Reloadable[A]]] =
+  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
     reloadableImpl3[D, A](config, c.Expr[String](q"$emptyString"))(decoder)
 
   def reloadableImpl3[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String]
-  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[Managed[ReactiveConfigException, Reloadable[A]]] =
+  )(decoder: c.Expr[ConfigDecoder[Sensitive, D]]): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] =
     reloadableImpl[D, A](config, prefix, true)
 
   def reloadableImpl[D: WeakTypeTag, A: WeakTypeTag](
       config: c.Expr[ReactiveConfig[D]],
       prefix: c.Expr[String],
       sensitive: Boolean
-  ): c.Expr[Managed[ReactiveConfigException, Reloadable[A]]] = {
+  ): c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]] = {
     val classSymbol   = ensureCaseClass[A]
     val annotations   = extractConstructorAnnotations(classSymbol)
     val prefixLiteral = extractPrefixLiteral(prefix)
-    c.Expr[Managed[ReactiveConfigException, Reloadable[A]]](
+    c.Expr[ZIO[Scope, ReactiveConfigException, Reloadable[A]]](
       reloadableDefs(weakTypeOf[D], prefixLiteral, classSymbol.asType.name, annotations)
     )
   }

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/package.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/package.scala
@@ -1,6 +1,7 @@
 package com.github.fit51.reactiveconfig.zio
 
 import com.github.fit51.reactiveconfig.{ReactiveConfigException, Sensitive}
+import com.github.fit51.reactiveconfig.generic.Configuration
 import com.github.fit51.reactiveconfig.generic.RootReactiveConfig
 import com.github.fit51.reactiveconfig.parser.ConfigDecoder
 import com.github.fit51.reactiveconfig.zio.config.ReactiveConfig
@@ -15,19 +16,20 @@ package object generic {
 
   def deriveReloadable[D, A](
       config: ReactiveConfig[D]
-  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
+  )(implicit cfg: Configuration): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl0[D, A]
 
   def deriveReloadable[D, A](
       config: ReactiveConfig[D],
       prefix: String
-  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
+  )(implicit cfg: Configuration): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl1[D, A]
 
   def deriveSensitiveReloadable[D, A](
       config: ReactiveConfig[D]
   )(implicit
-      decoder: ConfigDecoder[Sensitive, D]
+      decoder: ConfigDecoder[Sensitive, D],
+      cfg: Configuration
   ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl2[D, A]
 
@@ -35,7 +37,8 @@ package object generic {
       config: ReactiveConfig[D],
       prefix: String
   )(implicit
-      decoder: ConfigDecoder[Sensitive, D]
+      decoder: ConfigDecoder[Sensitive, D],
+      cfg: Configuration
   ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl3[D, A]
 

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/package.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/generic/package.scala
@@ -15,20 +15,20 @@ package object generic {
 
   def deriveReloadable[D, A](
       config: ReactiveConfig[D]
-  ): Managed[ReactiveConfigException, Reloadable[A]] =
+  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl0[D, A]
 
   def deriveReloadable[D, A](
       config: ReactiveConfig[D],
       prefix: String
-  ): Managed[ReactiveConfigException, Reloadable[A]] =
+  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl1[D, A]
 
   def deriveSensitiveReloadable[D, A](
       config: ReactiveConfig[D]
   )(implicit
       decoder: ConfigDecoder[Sensitive, D]
-  ): Managed[ReactiveConfigException, Reloadable[A]] =
+  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl2[D, A]
 
   def deriveSensitiveReloadable[D, A](
@@ -36,7 +36,7 @@ package object generic {
       prefix: String
   )(implicit
       decoder: ConfigDecoder[Sensitive, D]
-  ): Managed[ReactiveConfigException, Reloadable[A]] =
+  ): ZIO[Scope, ReactiveConfigException, Reloadable[A]] =
     macro ReloadableMacro.reloadableImpl3[D, A]
 
   @compileTimeOnly("enable macro paradise to expand macro annotations")

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/instances/EffectInstances.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/instances/EffectInstances.scala
@@ -1,22 +1,21 @@
 package com.github.fit51.reactiveconfig.zio.instances
 
 import com.github.fit51.reactiveconfig.typeclasses._
-import com.typesafe.scalalogging.StrictLogging
 import zio._
 
-trait EffectInstances extends StrictLogging {
+trait EffectInstances {
 
   implicit def effectForZio[R, E]: Effect[ZIO[R, E, *]] =
     new Effect[ZIO[R, E, *]] {
       override def pure[A](a: A): ZIO[R, E, A] =
-        UIO.succeed(a)
+        ZIO.succeed(a)
 
       override def sync[A](thunk: () => A): ZIO[R, E, A] =
-        ZIO.effectTotal(thunk())
+        ZIO.succeed(thunk())
 
       override def async[A](cb: (A => Unit) => ZIO[R, E, Unit]): ZIO[R, E, A] =
-        ZIO.effectAsyncM { innerCb =>
-          cb(a => innerCb(UIO.succeed(a)))
+        ZIO.asyncZIO { innerCb =>
+          cb(a => innerCb(ZIO.succeed(a)))
         }
 
       override def map[A, B](fa: ZIO[R, E, A])(f: A => B): ZIO[R, E, B] =
@@ -29,16 +28,16 @@ trait EffectInstances extends StrictLogging {
         fa.forkDaemon.unit
 
       override def parallelTraverse(fas: List[ZIO[R, E, Unit]]): ZIO[R, E, Unit] =
-        ZIO.foreachPar_(fas)(identity)
+        ZIO.foreachParDiscard(fas)(identity)
 
       override def info(message: String): ZIO[R, E, Unit] =
-        UIO.effectTotal(logger.info(message))
+        ZIO.logInfo(message)
 
       override def warn(message: String): ZIO[R, E, Unit] =
-        UIO.effectTotal(logger.warn(message))
+        ZIO.logWarning(message)
 
       override def warn(message: String, e: Throwable): ZIO[R, E, Unit] =
-        UIO.effectTotal(logger.warn(message, e))
+        ZIO.logWarningCause(message, Cause.fail(e))
     }
 
   implicit def handleTo[E]: HandleTo[IO[E, *], UIO, E] =
@@ -54,16 +53,16 @@ trait EffectInstances extends StrictLogging {
   implicit def zioResource[R, E]: Resource[ResourceLike, ZIO[R, E, *]] =
     new Resource[ResourceLike, ZIO[R, E, *]] {
       override def pure[A](a: A): ResourceLike[ZIO[R, E, *], A] =
-        Allocate(UIO.succeed((a, UIO.unit)))
+        Allocate(ZIO.succeed((a, ZIO.unit)))
 
       override def liftF[A](fa: ZIO[R, E, A]): ResourceLike[ZIO[R, E, *], A] =
-        Allocate(fa.map(a => (a, UIO.unit)))
+        Allocate(fa.map(a => (a, ZIO.unit)))
 
       override def make[A](acquire: ZIO[R, E, A])(release: A => ZIO[R, E, Unit]): ResourceLike[ZIO[R, E, *], A] =
         Allocate(acquire.map(a => (a, release(a))))
 
       override def map[A, B](ra: ResourceLike[ZIO[R, E, *], A])(f: A => B): ResourceLike[ZIO[R, E, *], B] =
-        FlatMap(ra, (a: A) => Allocate(UIO.succeed((f(a), UIO.unit))))
+        FlatMap(ra, (a: A) => Allocate(ZIO.succeed((f(a), ZIO.unit))))
 
       override def flatMap[A, B](
           ra: ResourceLike[ZIO[R, E, *], A]

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/reloadable/ConstReloadable.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/reloadable/ConstReloadable.scala
@@ -1,53 +1,62 @@
 package com.github.fit51.reactiveconfig.zio.reloadable
 
+import java.util.concurrent.atomic.AtomicReference
+
 import cats.kernel.Eq
-import com.github.fit51.reactiveconfig.reloadable.{ReloadBehaviour, Subscriber}
-import com.github.fit51.reactiveconfig.typeclasses.{Allocate, Effect, Resource, ResourceLike}
-import zio._
+import com.github.fit51.reactiveconfig.reloadable.{AtomicUtils, ReloadBehaviour, Subscriber}
+import com.github.fit51.reactiveconfig.typeclasses.{Effect, Resource, ResourceLike}
+import com.github.fit51.reactiveconfig.typeclasses.Resource._
+import zio.{Scope, UIO, URIO, ZIO}
 
 private class ConstReloadable[T](t: T) extends Reloadable[T] {
+
+  private val subscribers: AtomicReference[List[Subscriber[UIO, T]]] = new AtomicReference(Nil)
 
   override def unsafeGet: T =
     t
 
   override val get: UIO[T] =
-    UIO.succeed(t)
+    ZIO.succeed(t)
 
   override def map[B](
       f: T => B,
       reloadBehaviour: ReloadBehaviour[UIO, T, B]
-  ): UManaged[Reloadable[B]] =
-    Managed.succeed(new ConstReloadable[B](f(t)))
+  ): UIO[Reloadable[B]] =
+    ZIO.succeed(new ConstReloadable[B](f(t)))
 
   override def mapF[R, E, B](
       f: T => ZIO[R, E, B],
       reloadBehaviour: ReloadBehaviour[ZIO[R, E, *], T, B]
-  ): ZManaged[R, E, Reloadable[B]] =
-    f(t).map(new ConstReloadable(_)).toManaged_
+  ): ZIO[R, E, Reloadable[B]] =
+    f(t).map(new ConstReloadable(_))
 
   override def combine[B, C](
       other: Reloadable[B],
       reloadBehaviour: ReloadBehaviour[UIO, (T, B), C]
-  )(f: (T, B) => C): UManaged[Reloadable[C]] =
-    other.get.map(f(t, _)).map(new ConstReloadable(_)).toManaged_
+  )(f: (T, B) => C): UIO[Reloadable[C]] =
+    other.get.map(f(t, _)).map(new ConstReloadable(_))
 
   override def combineF[R, E, B, C](
       other: Reloadable[B],
       reloadBehaviour: ReloadBehaviour[ZIO[R, E, *], (T, B), C]
-  )(f: (T, B) => ZIO[R, E, C]): ZManaged[R, E, Reloadable[C]] =
-    other.get.flatMap(f(t, _)).map(new ConstReloadable(_)).toManaged_
+  )(f: (T, B) => ZIO[R, E, C]): ZIO[R, E, Reloadable[C]] =
+    other.get.flatMap(f(t, _)).map(new ConstReloadable(_))
 
   override def forEachF[R](f: T => URIO[R, Unit]): URIO[R, Nothing] =
-    f(t) *> UIO.never
+    f(t) *> ZIO.never
 
-  override def distinctByKey[K: Eq](makeKey: T => K): UManaged[Reloadable[T]] =
-    Managed.succeed(new ConstReloadable(t))
+  override def distinctByKey[K: Eq](makeKey: T => K): UIO[Reloadable[T]] =
+    ZIO.succeed(new ConstReloadable(t))
 
-  override def mapManaged[R, E, B](f: T => ZManaged[R, E, B]): ZManaged[R, E, Reloadable[B]] =
+  override def mapScoped[R, E, B](f: T => ZIO[R with Scope, E, B]): ZIO[R with Scope, E, Reloadable[B]] =
     f(t).map(new ConstReloadable(_))
 
   override protected[reactiveconfig] def subscribe[G[_]](
       subscriber: Subscriber[UIO, T]
   )(implicit effect: Effect[G], resource: Resource[ResourceLike, G]): ResourceLike[G, Unit] =
-    Allocate[G, Unit](effect.pure(((), effect.unit)))
+    resource.make(effect.sync { () =>
+      AtomicUtils.update(subscribers)(subscriber :: _)
+    }) { _ =>
+      effect.sync(() => AtomicUtils.update(subscribers)(_.filter(_ != subscriber)))
+    } as (())
 }

--- a/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/reloadable/HugeCombines.scala
+++ b/core-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/reloadable/HugeCombines.scala
@@ -3,36 +3,36 @@ package com.github.fit51.reactiveconfig.zio.reloadable
 import com.github.fit51.reactiveconfig.reloadable.{HugeCombines => HC, _}
 import com.github.fit51.reactiveconfig.typeclasses._
 import com.github.fit51.reactiveconfig.zio.reloadable.Reloadable._
-import zio._
+import zio.{Scope, UIO, URIO, ZIO}
 
 trait HugeCombines {
 
   def combine[A1, A2, Result](
       ra1: Reloadable[A1],
       ra2: Reloadable[A2]
-  )(f: (A1, A2) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, Result](
       ra1: Reloadable[A1],
       ra2: Reloadable[A2],
       ra3: Reloadable[A3]
-  )(f: (A1, A2, A3) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, Result](
       ra1: Reloadable[A1],
       ra2: Reloadable[A2],
       ra3: Reloadable[A3],
       ra4: Reloadable[A4]
-  )(f: (A1, A2, A3, A4) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, Result](
       ra1: Reloadable[A1],
@@ -40,10 +40,10 @@ trait HugeCombines {
       ra3: Reloadable[A3],
       ra4: Reloadable[A4],
       ra5: Reloadable[A5]
-  )(f: (A1, A2, A3, A4, A5) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, Result](
       ra1: Reloadable[A1],
@@ -52,10 +52,10 @@ trait HugeCombines {
       ra4: Reloadable[A4],
       ra5: Reloadable[A5],
       ra6: Reloadable[A6]
-  )(f: (A1, A2, A3, A4, A5, A6) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, Result](
       ra1: Reloadable[A1],
@@ -65,10 +65,10 @@ trait HugeCombines {
       ra5: Reloadable[A5],
       ra6: Reloadable[A6],
       ra7: Reloadable[A7]
-  )(f: (A1, A2, A3, A4, A5, A6, A7) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, Result](
       ra1: Reloadable[A1],
@@ -79,10 +79,10 @@ trait HugeCombines {
       ra6: Reloadable[A6],
       ra7: Reloadable[A7],
       ra8: Reloadable[A8]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, Result](
       ra1: Reloadable[A1],
@@ -94,10 +94,10 @@ trait HugeCombines {
       ra7: Reloadable[A7],
       ra8: Reloadable[A8],
       ra9: Reloadable[A9]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, Result](
       ra1: Reloadable[A1],
@@ -110,10 +110,10 @@ trait HugeCombines {
       ra8: Reloadable[A8],
       ra9: Reloadable[A9],
       ra10: Reloadable[A10]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, Result](
       ra1: Reloadable[A1],
@@ -127,10 +127,10 @@ trait HugeCombines {
       ra9: Reloadable[A9],
       ra10: Reloadable[A10],
       ra11: Reloadable[A11]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, Result](
       ra1: Reloadable[A1],
@@ -145,10 +145,10 @@ trait HugeCombines {
       ra10: Reloadable[A10],
       ra11: Reloadable[A11],
       ra12: Reloadable[A12]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, Result](
       ra1: Reloadable[A1],
@@ -164,10 +164,10 @@ trait HugeCombines {
       ra11: Reloadable[A11],
       ra12: Reloadable[A12],
       ra13: Reloadable[A13]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, Result](
       ra1: Reloadable[A1],
@@ -184,10 +184,10 @@ trait HugeCombines {
       ra12: Reloadable[A12],
       ra13: Reloadable[A13],
       ra14: Reloadable[A14]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, Result](
       ra1: Reloadable[A1],
@@ -205,10 +205,10 @@ trait HugeCombines {
       ra13: Reloadable[A13],
       ra14: Reloadable[A14],
       ra15: Reloadable[A15]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, Result](
       ra1: Reloadable[A1],
@@ -227,10 +227,10 @@ trait HugeCombines {
       ra14: Reloadable[A14],
       ra15: Reloadable[A15],
       ra16: Reloadable[A16]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, Result](
       ra1: Reloadable[A1],
@@ -250,10 +250,10 @@ trait HugeCombines {
       ra15: Reloadable[A15],
       ra16: Reloadable[A16],
       ra17: Reloadable[A17]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, Result](
       ra1: Reloadable[A1],
@@ -274,10 +274,10 @@ trait HugeCombines {
       ra16: Reloadable[A16],
       ra17: Reloadable[A17],
       ra18: Reloadable[A18]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, Result](
       ra1: Reloadable[A1],
@@ -299,10 +299,10 @@ trait HugeCombines {
       ra17: Reloadable[A17],
       ra18: Reloadable[A18],
       ra19: Reloadable[A19]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, Result](
       ra1: Reloadable[A1],
@@ -325,10 +325,10 @@ trait HugeCombines {
       ra18: Reloadable[A18],
       ra19: Reloadable[A19],
       ra20: Reloadable[A20]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, Result](
       ra1: Reloadable[A1],
@@ -352,10 +352,10 @@ trait HugeCombines {
       ra19: Reloadable[A19],
       ra20: Reloadable[A20],
       ra21: Reloadable[A21]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20, ra21)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20, ra21)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 
   def combine[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, Result](
       ra1: Reloadable[A1],
@@ -380,8 +380,8 @@ trait HugeCombines {
       ra20: Reloadable[A20],
       ra21: Reloadable[A21],
       ra22: Reloadable[A22]
-  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => Result): UManaged[Reloadable[Result]] =
+  )(f: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) => Result): URIO[Scope, Reloadable[Result]] =
     new ResourceLikeOps[Any, Nothing, RawReloadableImpl[UIO, ResourceLike, Result]](
-      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20, ra21, ra22)(f.tupled.andThen(UIO.succeed(_)))
-    ).toManaged.map(new ReloadableImpl(_))
+      HC.combine(ra1, ra2, ra3, ra4, ra5, ra6, ra7, ra8, ra9, ra10, ra11, ra12, ra13, ra14, ra15, ra16, ra17, ra18, ra19, ra20, ra21, ra22)(f.tupled.andThen(ZIO.succeed(_)))
+    ).toScoped.map(new ReloadableImpl(_))
 }

--- a/core-zio/src/test/scala/com/github/fit51/reactiveconfig/zio/generic/AnnotationTest.scala
+++ b/core-zio/src/test/scala/com/github/fit51/reactiveconfig/zio/generic/AnnotationTest.scala
@@ -85,22 +85,22 @@ class AnnotationTest extends WordSpecLike with Matchers {
 
     "generate Reloadable for case classes with prefix" in {
       val expected = NotSoPlain2(42, false, 2.5)
-      val task     = NotSoPlain2.reloadable(config).use(_.get)
-      runtime.unsafeRunSync(task).toEither shouldBe Right(expected)
+      val task     = ZIO.scoped(NotSoPlain2.reloadable(config).flatMap(_.get))
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(task)) shouldBe Exit.Success(expected)
     }
 
     "generate Reloadable for huge case classes" in {
       val expected = Enormous2(
         0, 1, 2, 3, 4, true, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
       )
-      val task = Enormous2.reloadable(config).use(_.get)
-      runtime.unsafeRunSync(task).toEither shouldBe Right(expected)
+      val task = ZIO.scoped(Enormous2.reloadable(config).flatMap(_.get))
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(task)) shouldBe Exit.Success(expected)
     }
 
     "generate Reloadable for sensitive class" in {
       val expected = Config(SensitiveConfig("user", Sensitive("passpass")), true)
-      val task     = Config.reloadable(config)(sensitiveDecoder).use(_.get)
-      runtime.unsafeRunSync(task).toEither shouldBe Right(expected)
+      val task     = ZIO.scoped(Config.reloadable(config)(sensitiveDecoder).flatMap(_.get))
+      Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(task)) shouldBe Exit.Success(expected)
     }
 
     "not compile for empty case classes" in {

--- a/core-zio/src/test/scala/com/github/fit51/reactiveconfig/zio/reloadable/ReloadableTest.scala
+++ b/core-zio/src/test/scala/com/github/fit51/reactiveconfig/zio/reloadable/ReloadableTest.scala
@@ -6,16 +6,16 @@ import org.mockito.Mockito.{times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.mockito.MockitoSugar
-import zio._
-import zio.clock.Clock
-import zio.duration._
+import zio.{Reloadable => _, _}
 
 import scala.collection.{immutable, mutable}
 import scala.util.control.NoStackTrace
 
 class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
 
-  val runtime = Runtime.default
+  val runtime = Runtime.default.withEnvironment {
+    ZEnvironment(Clock.ClockLive)
+  }
 
   trait UStoppingService[A, B] {
     def stop(a: A): UIO[B]
@@ -37,12 +37,14 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
 
   trait mocks {}
 
-  def intervalAtFixedRate(initialDelay: Duration, period: Duration, left: Int)(f: Int => UIO[Unit]): RIO[Clock, Unit] =
+  def intervalAtFixedRate(initialDelay: Duration, period: Duration, left: Int)(
+      f: Int => UIO[Unit]
+  ): RIO[Clock, Unit] =
     ZIO.sleep(initialDelay) *> intervalAtFixedRate(period, 0, left)(f)
 
   def intervalAtFixedRate(period: Duration, counter: Int, left: Int)(f: Int => UIO[Unit]): RIO[Clock, Unit] =
     if (left == 0) {
-      UIO.unit
+      ZIO.unit
     } else {
       f(counter) *> ZIO.sleep(period) *> intervalAtFixedRate(period, counter + 1, left - 1)(f)
     }
@@ -50,7 +52,7 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
   def delayedList[X](list: List[X], period: Duration)(f: X => UIO[Unit]): RIO[Clock, Unit] =
     list match {
       case immutable.Nil =>
-        IO.unit
+        ZIO.unit
       case head :: tail =>
         ZIO.sleep(period) *> f(head) *> delayedList(tail, period)(f)
     }
@@ -60,53 +62,50 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
   "ZioReloadable" should {
 
     "be able to return new data using get" in new mocks {
-      val zio = Reloadable.root("initial").use { case (reloadable, updater) =>
+      val zio = ZIO.scoped {
         for {
-          _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
-          initial <- reloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          first   <- reloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          second  <- reloadable.get
+          (reloadable, updater) <- Reloadable.root("initial")
+          _                     <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
+          initial               <- reloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          first                 <- reloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          second                <- reloadable.get
         } yield {
           initial shouldBe "initial"
           first shouldBe "0"
           second shouldBe "1"
         }
       }
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
     }
 
     "be able to change its reload behaviour using map" in new mocks {
       val function = (s: String) => s"${s}_changed"
-      val zio = Reloadable
-        .root("initial")
-        .flatMap { case (reloadable, updater) =>
-          reloadable.map(function) &&& ZManaged.succeed(updater)
+      val zio =
+        for {
+          (reloadable, updater) <- Reloadable.root("initial")
+          mappedReloadable      <- reloadable.map(function)
+          _                     <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
+          initial               <- mappedReloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          first                 <- mappedReloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          second                <- mappedReloadable.get
+        } yield {
+          initial shouldBe "initial_changed"
+          first shouldBe "0_changed"
+          second shouldBe "1_changed"
         }
-        .use { case (mappedReloadable, updater) =>
-          for {
-            _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
-            initial <- mappedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            first   <- mappedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            second  <- mappedReloadable.get
-          } yield {
-            initial shouldBe "initial_changed"
-            first shouldBe "0_changed"
-            second shouldBe "1_changed"
-          }
-        }
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "be able to accept behavior using different ReloadBehaviour" in new mocks {
-      val function = (s: String) => UIO.succeed(s"${s}_changed")
+      val function = (s: String) => ZIO.succeed(s"${s}_changed")
 
       val stop = mock[UStoppingService[String, String]]
       when(stop.stop(any())).thenAnswer((invocation: InvocationOnMock) =>
-        UIO.succeed(invocation.getArgument[String](0))
+        ZIO.succeed(invocation.getArgument[String](0))
       )
 
       val restart = mock[URestartingService[String, String]]
@@ -114,143 +113,124 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
         function(invocation.getArgument[String](0))
       )
 
-      val zio = (for {
+      val zio = for {
         (initialReloadable, updater) <- Reloadable.root("initial")
         mappedReloadable1            <- initialReloadable.mapF(function, Stop((s: String) => stop.stop(s).unit))
         mappedReloadable2 <- initialReloadable.mapF(
           function,
-          Restart[UIO, String, String]((a, b) => restart.restart(a, b), _ => IO.unit)
+          Restart[UIO, String, String]((a, b) => restart.restart(a, b), _ => ZIO.unit)
         )
-      } yield (mappedReloadable1, mappedReloadable2, updater)).use {
-        case (mappedReloadable1, mappedReloadable2, updater) =>
-          for {
-            _        <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
-            initial1 <- mappedReloadable1.get
-            initial2 <- mappedReloadable2.get
-            _        <- ZIO.sleep(3 seconds)
-            _ = verify(stop).stop("initial_changed")
-            _ = verify(restart).restart("0", "initial_changed")
-            first1  <- mappedReloadable1.get
-            first2  <- mappedReloadable2.get
-            _       <- ZIO.sleep(3 seconds)
-            second1 <- mappedReloadable1.get
-            second2 <- mappedReloadable2.get
-            _ = verify(stop).stop("0_changed")
-            _ = verify(restart).restart("1", "0_changed")
-          } yield {
-            initial1 shouldBe "initial_changed"
-            initial2 shouldBe "initial_changed"
-            first1 shouldBe "0_changed"
-            first2 shouldBe "0_changed"
-            second1 shouldBe "1_changed"
-            second2 shouldBe "1_changed"
-          }
+        _        <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
+        initial1 <- mappedReloadable1.get
+        initial2 <- mappedReloadable2.get
+        _        <- ZIO.sleep(3 seconds)
+        _ = verify(stop).stop("initial_changed")
+        _ = verify(restart).restart("0", "initial_changed")
+        first1  <- mappedReloadable1.get
+        first2  <- mappedReloadable2.get
+        _       <- ZIO.sleep(3 seconds)
+        second1 <- mappedReloadable1.get
+        second2 <- mappedReloadable2.get
+        _ = verify(stop).stop("0_changed")
+        _ = verify(restart).restart("1", "0_changed")
+      } yield {
+        initial1 shouldBe "initial_changed"
+        initial2 shouldBe "initial_changed"
+        first1 shouldBe "0_changed"
+        first2 shouldBe "0_changed"
+        second1 shouldBe "1_changed"
+        second2 shouldBe "1_changed"
       }
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "be able to change its reload behaviour to dirty computation in pure way using mapF" in new mocks {
-      val function = (s: String) => IO(s"${s}_changed")
+      val function = (s: String) => ZIO.succeed(s"${s}_changed")
 
-      val zio = Reloadable
-        .root("initial")
-        .flatMap { case (reloadable, updater) =>
-          reloadable.mapF(function) &&& ZManaged.succeed(updater)
-        }
-        .use { case (mappedReloadable, updater) =>
-          for {
-            _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
-            initial <- mappedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            first   <- mappedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            second  <- mappedReloadable.get
-          } yield {
-            initial shouldBe "initial_changed"
-            first shouldBe "0_changed"
-            second shouldBe "1_changed"
-          }
-        }
-        .timeout(7 seconds)
-      runtime.unsafeRun(zio)
+      val zio =
+        (for {
+          (reloadable, updater) <- Reloadable.root("initial")
+          mappedReloadable      <- reloadable.mapF[Any, Nothing, String](function)
+          _                     <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater.compose(_.toString())).fork
+          initial               <- mappedReloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          first                 <- mappedReloadable.get
+          _                     <- ZIO.sleep(3 seconds)
+          second                <- mappedReloadable.get
+        } yield {
+          initial shouldBe "initial_changed"
+          first shouldBe "0_changed"
+          second shouldBe "1_changed"
+        }).timeout(7 seconds)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "be able to produce new reloadable by combining sources of this and that reloadables " in new mocks {
       val function = (s: String, i: Int) => Data(s, i)
 
-      val zio = (for {
+      val zio = for {
         (initialReloadable1, updater1) <- Reloadable.root("initial")
         (initialReloadable2, updater2) <- Reloadable.root(-1)
         combinedReloadable             <- initialReloadable1.combine(initialReloadable2)(function)
-      } yield (combinedReloadable, updater1, updater2)).use { case (combinedReloadable, updater1, updater2) =>
-        for {
-          _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater1.compose(_.toString())).fork
-          _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater2).fork
-          initial <- combinedReloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          first   <- combinedReloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          second  <- combinedReloadable.get
-        } yield {
-          initial shouldBe Data("initial", -1)
-          first shouldBe Data("0", 0)
-          second shouldBe Data("1", 1)
-        }
+        _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater1.compose(_.toString())).fork
+        _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater2).fork
+        initial <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        first   <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        second  <- combinedReloadable.get
+      } yield {
+        initial shouldBe Data("initial", -1)
+        first shouldBe Data("0", 0)
+        second shouldBe Data("1", 1)
       }
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "be able to produce new reloadable by combining sources of this and that reloadables with dirty function " in new mocks {
-      val function = (s: String, i: Int) => UIO.succeed(Data(s, i))
+      val function = (s: String, i: Int) => ZIO.succeed(Data(s, i))
 
       val zio = (for {
         (initialReloadable1, updater1) <- Reloadable.root("initial")
         (initialReloadable2, updater2) <- Reloadable.root(-1)
         combinedReloadable             <- initialReloadable1.combineF(initialReloadable2)(function)
-      } yield (combinedReloadable, updater1, updater2)).use { case (combinedReloadable, updater1, updater2) =>
-        for {
-          _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater1.compose(_.toString())).fork
-          _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater2).fork
-          initial <- combinedReloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          first   <- combinedReloadable.get
-          _       <- ZIO.sleep(3 seconds)
-          second  <- combinedReloadable.get
-        } yield {
-          initial shouldBe Data("initial", -1)
-          first shouldBe Data("0", 0)
-          second shouldBe Data("1", 1)
-        }
-      }.timeout(7 seconds)
-      runtime.unsafeRun(zio)
+        _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater1.compose(_.toString())).fork
+        _       <- intervalAtFixedRate(2 seconds, 2 seconds, 2)(updater2).fork
+        initial <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        first   <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        second  <- combinedReloadable.get
+      } yield {
+        initial shouldBe Data("initial", -1)
+        first shouldBe Data("0", 0)
+        second shouldBe Data("1", 1)
+      }).timeout(7 seconds)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "survive after errors in stop handler" in new mocks {
       val stop = mock[StoppingService[Any, String, String]]
       when(stop.stop(any())).thenReturn(
-        IO.fail(exception),
-        IO.fail(exception),
-        IO.succeed("stopped")
+        ZIO.fail(exception),
+        ZIO.fail(exception),
+        ZIO.succeed("stopped")
       )
 
-      val zio = Reloadable
-        .root("initial")
-        .flatMap { case (reloadable, updater) =>
-          reloadable.mapF(s => UIO.succeed(s * 2), Stop((s: String) => stop.stop(s).unit)) &&& ZManaged.succeed(updater)
-        }
-        .use { case (mappedReloadable, updater) =>
-          for {
-            _   <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork
-            _   <- ZIO.sleep(3500 millis)
-            cur <- mappedReloadable.get
-          } yield {
-            verify(stop, times(3)).stop(any())
-            cur shouldBe "22"
-          }
-        } *> ZIO.sleep(1500 millis)
+      val zio =
+        ZIO.scoped(for {
+          (reloadable, updater) <- Reloadable.root("initial")
+          mappedReloadable      <- reloadable.mapF(s => ZIO.succeed(s * 2), Stop((s: String) => stop.stop(s).unit))
+          _                     <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString)).fork
+          _                     <- ZIO.sleep(3500 millis)
+          cur                   <- mappedReloadable.get
+        } yield {
+          verify(stop, times(3)).stop(any())
+          cur shouldBe "22"
+        }) *> ZIO.sleep(1500 millis)
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
       verify(stop, times(4)).stop(any())
     }
 
@@ -260,62 +240,55 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
       when(restart.restart(any(), any())).thenAnswer { (invocation: InvocationOnMock) =>
         counter += 1
         if (counter == 2) {
-          Task.fail(exception)
+          ZIO.fail(exception)
         } else {
-          UIO.succeed(invocation.getArgument[String](0) + invocation.getArgument[String](1))
+          ZIO.succeed(invocation.getArgument[String](0) + invocation.getArgument[String](1))
         }
       }
 
-      val zio = Reloadable
-        .root("initial")
-        .flatMap { case (reloadable, updater) =>
-          reloadable.mapF(
-            s => UIO.succeed(s * 2),
-            Restart((a, b) => restart.restart(a, b), (_: String) => UIO.unit)
-          ) &&& ZManaged.succeed(updater)
-        }
-        .use { case (mappedReloadable, updater) =>
-          for {
-            _   <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork
-            _   <- ZIO.sleep(3500 millis)
-            cur <- mappedReloadable.get
-            _ = verify(restart, times(3)).restart(any(), any())
-            _ = verify(restart).restart("0", "initialinitial")
-            _ = verify(restart).restart("1", "0initialinitial")
-            _ = verify(restart).restart("2", "0initialinitial")
-          } yield cur shouldBe "20initialinitial"
-        } *> ZIO.sleep(1500 millis)
+      val zio =
+        ZIO.scoped(for {
+          (reloadable, updater) <- Reloadable.root("initial")
+          mappedReloadable <- reloadable.mapF(
+            s => ZIO.succeed(s * 2),
+            Restart((a, b) => restart.restart(a, b), (_: String) => ZIO.unit)
+          )
+          _   <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork
+          _   <- ZIO.sleep(3500 millis)
+          cur <- mappedReloadable.get
+          _ = verify(restart, times(3)).restart(any(), any())
+          _ = verify(restart).restart("0", "initialinitial")
+          _ = verify(restart).restart("1", "0initialinitial")
+          _ = verify(restart).restart("2", "0initialinitial")
+        } yield cur shouldBe "20initialinitial") *> ZIO.sleep(1500 millis)
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(zio).getOrThrow())
       verify(restart, times(3)).restart(any(), any())
     }
 
     "don't stop observable even for long stop operations" in new mocks {
       val stop = mock[StoppingService[Clock, String, String]]
       when(stop.stop(any())).thenReturn(ZIO.sleep(5.seconds).as(""))
-      val zio = (for {
+      val zio = for {
         (initialReloadable, updater) <- Reloadable.root("initial")
-        doubleF <- initialReloadable.mapF(s => UIO.succeed(s * 2), Stop((s: String) => stop.stop(s).unit))
-        maskF   <- doubleF.mapF(s => UIO.succeed(s.take(1) + "***"), Stop((s: String) => stop.stop(s).unit))
-      } yield (doubleF, maskF, updater)).use { case (doubleF, maskF, updater) =>
-        for {
-          _       <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork
-          _       <- ZIO.sleep(1100 millis)
-          double1 <- doubleF.get
-          mask1   <- maskF.get
+        doubleF <- initialReloadable.mapF(s => ZIO.succeed(s * 2), Stop((s: String) => stop.stop(s).unit))
+        maskF   <- doubleF.mapF(s => ZIO.succeed(s.take(1) + "***"), Stop((s: String) => stop.stop(s).unit))
+        _       <- intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork
+        _       <- ZIO.sleep(1100 millis)
+        double1 <- doubleF.get
+        mask1   <- maskF.get
 
-          _       <- ZIO.sleep(1 second)
-          double2 <- doubleF.get
-          mask2   <- maskF.get
-        } yield {
-          double1 shouldBe "00"
-          mask1 shouldBe "0***"
-          double2 shouldBe "11"
-          mask2 shouldBe "1***"
-        }
+        _       <- ZIO.sleep(1 second)
+        double2 <- doubleF.get
+        mask2   <- maskF.get
+      } yield {
+        double1 shouldBe "00"
+        mask1 shouldBe "0***"
+        double2 shouldBe "11"
+        mask2 shouldBe "1***"
       }
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "do side effects using forEachF" in new mocks {
@@ -323,15 +296,15 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
       val zio = Reloadable
         .root("initial")
         .flatMap { case (reloadable, updater) =>
-          reloadable.mapF(s => UIO.succeed(s * 2)) &&& ZManaged.succeed(updater)
+          reloadable.mapF[Any, Nothing, String](s => ZIO.succeed(s * 2)) <*> ZIO.succeed(updater)
         }
-        .use { case (mappedReloadable, updater) =>
+        .flatMap { case (mappedReloadable, updater) =>
           intervalAtFixedRate(1 second, 1 second, 10)(updater.compose(_.toString())).fork *>
-            mappedReloadable.forEachF(s => UIO.succeed(buffer += s))
+            mappedReloadable.forEachF(s => ZIO.succeed(buffer += s))
         }
         .timeout(2500 millis)
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
       buffer.toList shouldBe List("initialinitial", "00", "11")
     }
 
@@ -343,56 +316,49 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
         filteredR                    <- initialReloadable.distinctByKey(i => i * i * i)
         absR                         <- filteredR.map(_.abs)
         filtered2R                   <- absR.distinctByKey(identity)
-      } yield (filteredR, filtered2R, updater)).use { case (filteredR, filtered2R, updater) =>
-        for {
-          _      <- delayedList(List(1, 1, -1, -1, 2, 2, 2, 1, 1, -1, -1, 3, -3), 1 second)(updater).fork
-          fiber1 <- filteredR.forEachF(i => UIO.succeed(buffer1 += i)).fork
-          fiber2 <- filtered2R.forEachF(i => UIO.succeed(buffer2 += i)).fork
-          _      <- fiber1.join
-          _      <- fiber2.join
-        } yield ()
-      }.timeout(15 seconds)
+        _      <- delayedList(List(1, 1, -1, -1, 2, 2, 2, 1, 1, -1, -1, 3, -3), 1 second)(updater).fork
+        fiber1 <- filteredR.forEachF(i => ZIO.succeed(buffer1 += i)).fork
+        fiber2 <- filtered2R.forEachF(i => ZIO.succeed(buffer2 += i)).fork
+        _      <- fiber1.join
+        _      <- fiber2.join
+      } yield ()).timeout(15 seconds)
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
       buffer1.toList shouldBe List(0, 1, -1, 2, 1, -1, 3, -3)
       buffer2.toList shouldBe List(0, 1, 2, 1, 3)
     }
 
     "handle slow and fast mapped reloadables" in new mocks {
-      val zio = (for {
+      val zio = for {
         (initialReloadable, updater) <- Reloadable.root(0)
         fast1Reloadable              <- initialReloadable.map(_ + 1)
         fast2Reloadable              <- initialReloadable.map(_ * 2)
         slowReloadable               <- fast2Reloadable.mapF[Clock, Nothing, Int](i => ZIO.sleep(1 second).as(i + 1))
-      } yield (fast1Reloadable, fast2Reloadable, slowReloadable, updater)).use {
-        case (fast1Reloadable, fast2Reloadable, slowReloadable, updater) =>
-          for {
-            _               <- delayedList(List(1, 2, 3, 4), 0 second)(updater).fork
-            _               <- ZIO.sleep(2500 millis)
-            plusOne1        <- fast1Reloadable.get
-            doubled1        <- fast2Reloadable.get
-            doubledPlusOne1 <- slowReloadable.get
+        _                            <- delayedList(List(1, 2, 3, 4), 0 second)(updater).fork
+        _                            <- ZIO.sleep(2500 millis)
+        plusOne1                     <- fast1Reloadable.get
+        doubled1                     <- fast2Reloadable.get
+        doubledPlusOne1              <- slowReloadable.get
 
-            _               <- ZIO.sleep(1 second)
-            plusOne2        <- fast1Reloadable.get
-            doubled2        <- fast2Reloadable.get
-            doubledPlusOne2 <- slowReloadable.get
-          } yield {
-            plusOne1 shouldBe 4
-            doubled1 shouldBe 6
-            doubledPlusOne1 shouldBe 5
+        _               <- ZIO.sleep(1 second)
+        plusOne2        <- fast1Reloadable.get
+        doubled2        <- fast2Reloadable.get
+        doubledPlusOne2 <- slowReloadable.get
+      } yield {
+        plusOne1 shouldBe 4
+        doubled1 shouldBe 6
+        doubledPlusOne1 shouldBe 5
 
-            plusOne2 shouldBe 5
-            doubled2 shouldBe 8
-            doubledPlusOne2 shouldBe 7
-          }
+        plusOne2 shouldBe 5
+        doubled2 shouldBe 8
+        doubledPlusOne2 shouldBe 7
       }
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "handle slow and fast combined reloadables" in new mocks {
-      val zio = (for {
+      val zio = for {
         (initialReloadable1, updater1) <- Reloadable.root(0)
         (initialReloadable2, updater2) <- Reloadable.root(0)
 
@@ -400,27 +366,24 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
         slowMappedReloadable <- initialReloadable2.mapF[Clock, Nothing, Int](i => ZIO.sleep(1 second).as(i - 1))
 
         combined <- fastMappedReloadable.combineF(slowMappedReloadable)((a, b) => ZIO.sleep(2 seconds).as((a, b)))
-      } yield (combined, updater1, updater2)).use { case (combined, updater1, updater2) =>
-        for {
-          _ <- delayedList(List(1, 2, 3, 4), 0 second)(updater1).fork
-          _ <- delayedList(List(-1, -2, -3, -4), 0 second)(updater2).fork
+        _        <- delayedList(List(1, 2, 3, 4), 0 second)(updater1).fork
+        _        <- delayedList(List(-1, -2, -3, -4), 0 second)(updater2).fork
 
-          _      <- ZIO.sleep(2500 millis)
-          value1 <- combined.get
+        _      <- ZIO.sleep(2500 millis)
+        value1 <- combined.get
 
-          _      <- ZIO.sleep(2 seconds)
-          value2 <- combined.get
+        _      <- ZIO.sleep(2 seconds)
+        value2 <- combined.get
 
-          _      <- ZIO.sleep(2 seconds)
-          value3 <- combined.get
-        } yield {
-          value1 shouldBe (2, -1)
-          value2 shouldBe (2, -2)
-          value3 shouldBe (3, -2)
-        }
+        _      <- ZIO.sleep(2 seconds)
+        value3 <- combined.get
+      } yield {
+        value1 shouldBe (2, -1)
+        value2 shouldBe (2, -2)
+        value3 shouldBe (3, -2)
       }
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "combine several reloadables" in new mocks {
@@ -437,44 +400,40 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
           initialReloadable3,
           initialReloadable4
         )(Data.apply _)
-      } yield (combinedReloadable, updater1, updater2, updater3, updater4)).use {
-        case (combinedReloadable, updater1, updater2, updater3, updater4) =>
-          for {
-            _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater1.compose(_.toString())).fork
-            _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater2).fork
-            _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater3.compose(_ % 2 == 0)).fork
-            _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater4.compose(_.toDouble)).fork
-            initial <- combinedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            first   <- combinedReloadable.get
-            _       <- ZIO.sleep(3 seconds)
-            second  <- combinedReloadable.get
-          } yield {
-            initial shouldBe Data("initial", -1, true, -1d)
-            first shouldBe Data("1", 1, false, 1d)
-            second shouldBe Data("4", 4, true, 4d)
-          }
-      }.timeout(7 seconds)
-      runtime.unsafeRun(zio)
+        _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater1.compose(_.toString())).fork
+        _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater2).fork
+        _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater3.compose(_ % 2 == 0)).fork
+        _       <- intervalAtFixedRate(1 seconds, 1 seconds, 7)(updater4.compose(_.toDouble)).fork
+        initial <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        first   <- combinedReloadable.get
+        _       <- ZIO.sleep(3 seconds)
+        second  <- combinedReloadable.get
+      } yield {
+        initial shouldBe Data("initial", -1, true, -1d)
+        first shouldBe Data("1", 1, false, 1d)
+        second shouldBe Data("4", 4, true, 4d)
+      }).timeout(7 seconds)
+
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
 
     "map with managed" in new mocks {
       val zio = Ref
         .make[List[String]](Nil).tap { closedRef =>
-          (for {
-            (reloadable, updater) <- Reloadable.root("initial")
-            mappedReloadable <- reloadable.mapManaged { str =>
-              ZManaged.make(UIO.effectTotal(str.toUpperCase))(value => closedRef.update(value :: _))
-            }
-          } yield (mappedReloadable, updater)).use { case (reloadable, updater) =>
+          ZIO.scoped(
             for {
+              (reloadable, updater) <- Reloadable.root("initial")
+              mappedReloadable <- reloadable.mapScoped { str =>
+                ZIO.acquireRelease(ZIO.succeed(str.toUpperCase))(value => closedRef.update(value :: _))
+              }
               _            <- intervalAtFixedRate(1 seconds, 1 seconds, 2)(updater.compose(_.toString())).fork
-              initial      <- reloadable.get
+              initial      <- mappedReloadable.get
               _            <- ZIO.sleep(1500 millis)
-              second       <- reloadable.get
+              second       <- mappedReloadable.get
               secondClosed <- closedRef.get
               _            <- ZIO.sleep(1 second)
-              third        <- reloadable.get
+              third        <- mappedReloadable.get
               thirdClosed  <- closedRef.get
             } yield {
               initial shouldBe "INITIAL"
@@ -483,12 +442,12 @@ class ReloadableTest extends WordSpecLike with Matchers with MockitoSugar {
               secondClosed shouldBe List("INITIAL")
               thirdClosed shouldBe List("0", "INITIAL")
             }
-          }
+          )
         }.flatMap(_.get).map { closed =>
           closed shouldBe List("1", "0", "INITIAL")
         }
 
-      runtime.unsafeRun(zio)
+      Unsafe.unsafe(implicit u => runtime.unsafe.run(ZIO.scoped(zio)).getOrThrow())
     }
   }
 }

--- a/core/src/main/scala/com/github/fit51/reactiveconfig/generic/domain.scala
+++ b/core/src/main/scala/com/github/fit51/reactiveconfig/generic/domain.scala
@@ -1,5 +1,7 @@
 package com.github.fit51.reactiveconfig.generic
 
+import java.util.regex.Pattern
+
 import scala.annotation.StaticAnnotation
 
 trait RootReactiveConfig[D] {
@@ -10,3 +12,33 @@ trait RootReactiveConfig[D] {
 }
 
 class source(val path: String) extends StaticAnnotation
+
+case class Configuration(
+    transformMemberNames: String => String
+) {
+
+  def withSnakeCaseMemberNames: Configuration =
+    copy(transformMemberNames = Configuration.snakeCaseTransformation)
+
+  def withScreamingSnakeCaseTransformation: Configuration =
+    copy(transformMemberNames = Configuration.screamingSnakeCaseTransformation)
+}
+
+object Configuration {
+
+  val default: Configuration =
+    Configuration(identity)
+
+  private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+
+  val snakeCaseTransformation: String => String = s => {
+    val partial = basePattern.matcher(s).replaceAll("$1_$2")
+    swapPattern.matcher(partial).replaceAll("$1_$2").toLowerCase
+  }
+
+  val screamingSnakeCaseTransformation: String => String = s => {
+    val partial = basePattern.matcher(s).replaceAll("$1_$2")
+    swapPattern.matcher(partial).replaceAll("$1_$2").toUpperCase
+  }
+}

--- a/core/src/main/scala/com/github/fit51/reactiveconfig/reloadable/RawReloadable.scala
+++ b/core/src/main/scala/com/github/fit51/reactiveconfig/reloadable/RawReloadable.scala
@@ -149,7 +149,7 @@ class RawReloadableImpl[F[_], R[_[_], _], A](
   }
 }
 
-private object AtomicUtils {
+private[reactiveconfig] object AtomicUtils {
 
   def update[X](ref: AtomicReference[X])(mod: X => X): X = {
     var current = ref.get()

--- a/etcd-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/etcd/EtcdReactiveConfig.scala
+++ b/etcd-ce/src/main/scala/com/github/fit51/reactiveconfig/ce/etcd/EtcdReactiveConfig.scala
@@ -12,6 +12,7 @@ import cats.effect.concurrent.Ref
 import cats.effect.concurrent.Semaphore
 import cats.effect.syntax.concurrent._
 import cats.syntax.flatMap._
+import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.syntax.parallel._
 import com.github.fit51.reactiveconfig.Value
@@ -72,7 +73,7 @@ object EtcdReactiveConfig {
         .range(RangeRequest(key = keyRange.start.bytes, rangeEnd = keyRange.end.bytes), new Metadata())
         .map(_.kvs.toVector)
     }.map(_.flatten).map { allKvs =>
-      allKvs.partitionMap { kv =>
+      allKvs.partitionEither { kv =>
         decoder.parse(kv.value.utf8) match {
           case Success(parsed) =>
             val key   = kv.key.utf8

--- a/etcd-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/etcd/EtcdClient.scala
+++ b/etcd-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/etcd/EtcdClient.scala
@@ -24,13 +24,11 @@ trait EtcdClient {
 
 object EtcdClient {
 
-  val live =
-    (for {
-      kvClient <- ZIO.service[KVClient.ZService[Any, Any]]
-    } yield new EtcdClientImpl(kvClient): EtcdClient).toLayer
+  val live: RLayer[KVClient.Service, EtcdClient] =
+    ZLayer.fromFunction(EtcdClientImpl.apply _)
 }
 
-class EtcdClientImpl(kvClient: KVClient.ZService[Any, Any]) extends EtcdClient {
+private case class EtcdClientImpl(kvClient: KVClient.Service) extends EtcdClient {
 
   override def get(key: String): IO[Status, Option[KeyValue]] =
     kvClient.range(RangeRequest(key.bytes)).map(_.kvs.headOption)

--- a/etcd-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/etcd/EtcdReactiveConfig.scala
+++ b/etcd-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/etcd/EtcdReactiveConfig.scala
@@ -1,6 +1,7 @@
 package com.github.fit51.reactiveconfig.zio.etcd
 
 import cats.data.NonEmptySet
+import cats.syntax.foldable._
 import com.github.fit51.reactiveconfig.Value
 import com.github.fit51.reactiveconfig.config.ConfigState
 import com.github.fit51.reactiveconfig.etcd._
@@ -52,7 +53,7 @@ object EtcdReactiveConfig {
           )
         ).mapError(new GrpcError(_)).map(_.kvs.toVector)
     } map (_.flatten) map { allKvs =>
-      allKvs.partitionMap { kv =>
+      allKvs.partitionEither { kv =>
         decoder.parse(kv.value.utf8) match {
           case Success(parsed) =>
             val key   = kv.key.utf8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 1.6.1
+sbt.version = 1.6.2
 sbt.gigahorse = false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.2")
 addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "0.11.2")
 
 libraryDependencies ++= Seq(
-  "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.5.2"
+  "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0-test8"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.8.0")
-
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.4.6")
@@ -7,6 +5,9 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "1.0.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.2")
 addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "0.11.2")
+
+addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.4")
+addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "2.0.0")
 
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0-test8"

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,9 +1,0 @@
-resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "1.0.0")
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.0.0")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.4")
-addSbtPlugin("com.jsuereth"     % "sbt-pgp"      % "2.0.0")
-
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.1"

--- a/typesafe-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/typesafe/TypesafeReactiveConfig.scala
+++ b/typesafe-zio/src/main/scala/com/github/fit51/reactiveconfig/zio/typesafe/TypesafeReactiveConfig.scala
@@ -6,40 +6,39 @@ import java.nio.file.StandardWatchEventKinds
 import com.github.fit51.reactiveconfig.Value
 import com.github.fit51.reactiveconfig.config.ConfigState
 import com.github.fit51.reactiveconfig.parser.ConfigParser
-import com.github.fit51.reactiveconfig.typeclasses.Effect
 import com.github.fit51.reactiveconfig.typesafe.TypesafeUtils
 import com.github.fit51.reactiveconfig.zio.config.AbstractReactiveConfig
 import com.github.fit51.reactiveconfig.zio.reloadable.Reloadable._
 import zio._
 import zio.nio.file.{Path => ZPath, WatchService}
 
-class TypesafeReactiveConfig[D](stateRef: RefM[ConfigState[UIO, D]]) extends AbstractReactiveConfig[D](stateRef)
+class TypesafeReactiveConfig[D](stateRef: Ref.Synchronized[ConfigState[UIO, D]])
+    extends AbstractReactiveConfig[D](stateRef)
 
 object TypesafeReactiveConfig {
 
-  private val uioEffect: Effect[UIO] = Effect[UIO]
-
-  def live[D: Tag](path: Path)(implicit encoder: ConfigParser[D]) = (for {
-    watchService <- WatchService.forDefaultFileSystem
-    zpath = ZPath(path.getParent().toUri())
-    _        <- zpath.register(watchService, List(StandardWatchEventKinds.ENTRY_MODIFY)).toManaged(_.cancel)
-    stateRef <- parseConfig(path, -1).toManaged_.map(ConfigState[UIO, D](_, Map.empty)) >>= ZRefM.makeManaged
-    _ <- watchService.stream
-      .mapChunksM(ZIO.foreach(_)(_.reset).as(Chunk.unit))
-      .zipWithIndex
-      .mapM { case (_, idx) => parseConfig(path, idx).either }
-      .foreach {
-        case Right(newMap) =>
-          stateRef.update { state =>
-            state.fireUpdates(newMap).as(state.copy(values = newMap))
-          }
-        case Left(e) =>
-          uioEffect.warn("Unable to parse config", e)
-      }
-      .fork
-      .toManaged_
-  } yield new TypesafeReactiveConfig(stateRef)).toLayer
+  def live[D: Tag](path: Path)(implicit encoder: ConfigParser[D]): TaskLayer[TypesafeReactiveConfig[D]] = ZLayer.scoped(
+    for {
+      watchService <- WatchService.forDefaultFileSystem
+      zpath = ZPath(path.getParent().toUri())
+      _        <- ZIO.acquireRelease(zpath.register(watchService, List(StandardWatchEventKinds.ENTRY_MODIFY)))(_.cancel)
+      stateRef <- parseConfig(path, -1).map(ConfigState[UIO, D](_, Map.empty)).flatMap(Ref.Synchronized.make(_))
+      _ <- watchService.stream
+        .mapChunksZIO(ZIO.foreach(_)(_.reset).as(Chunk.unit))
+        .zipWithIndex
+        .mapZIO { case (_, idx) => parseConfig(path, idx).either }
+        .foreach {
+          case Right(newMap) =>
+            stateRef.updateZIO { state =>
+              state.fireUpdates(newMap).as(state.copy(values = newMap))
+            }
+          case Left(e) =>
+            ZIO.logWarningCause("Unable to parse config", Cause.fail(e))
+        }
+        .fork
+    } yield new TypesafeReactiveConfig(stateRef)
+  )
 
   private def parseConfig[D: ConfigParser](path: Path, index: Long): Task[Map[String, Value[D]]] =
-    Task.effect(TypesafeUtils.parseConfig(path)).flatMap(TypesafeUtils.parseValuesInMap[UIO, D](_, index))
+    ZIO.attempt(TypesafeUtils.parseConfig(path)).flatMap(TypesafeUtils.parseValuesInMap[UIO, D](_, index))
 }


### PR DESCRIPTION
Actually two independent changes:
1. Migrate to ZIO2.0
2. Make `@source` annotation optional. If this annotation is omitted then we should use variable name as path to configuration